### PR TITLE
Add KeyGame controller and frontend interfaces

### DIFF
--- a/backend/controllers/keygame.go
+++ b/backend/controllers/keygame.go
@@ -1,0 +1,63 @@
+package controllers
+
+import (
+	"net/http"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+	"github.com/gin-gonic/gin"
+)
+
+// POST /keygames
+func CreateKeyGame(c *gin.Context) {
+	var body entity.KeyGame
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
+		return
+	}
+	// ตรวจสอบเกมที่เกี่ยวข้อง
+	var game entity.Game
+	db := configs.DB()
+	if tx := db.First(&game, body.GameID); tx.RowsAffected == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "game_id not found"})
+		return
+	}
+	if err := db.Create(&body).Error; err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, body)
+}
+
+// GET /keygames
+func FindKeyGames(c *gin.Context) {
+	var rows []entity.KeyGame
+	db := configs.DB().Preload("Game").Preload("OrderItem")
+	if gameID := c.Query("game_id"); gameID != "" {
+		db = db.Where("game_id = ?", gameID)
+	}
+	if err := db.Find(&rows).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+// GET /keygames/:id
+func FindKeyGameByID(c *gin.Context) {
+	var row entity.KeyGame
+	if tx := configs.DB().Preload("Game").Preload("OrderItem").First(&row, c.Param("id")); tx.RowsAffected == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id not found"})
+		return
+	}
+	c.JSON(http.StatusOK, row)
+}
+
+// DELETE /keygames/:id
+func DeleteKeyGame(c *gin.Context) {
+	if tx := configs.DB().Exec("DELETE FROM key_games WHERE id = ?", c.Param("id")); tx.RowsAffected == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "id not found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "deleted successful"})
+}

--- a/backend/entity/keygame.go
+++ b/backend/entity/keygame.go
@@ -6,6 +6,11 @@ import (
 
 type KeyGame struct {
 	gorm.Model
-	Key  string `json:"key" gorm:"uniqueIndex; type:text; default:(lower(hex(randomblob(16))))"`
-	Game Game   `json:"game"`
+	Key    string `json:"key" gorm:"uniqueIndex; type:text; default:(lower(hex(randomblob(16))))"`
+	GameID uint   `json:"game_id"`
+	Game   Game   `json:"game"`
+
+	// หากคีย์ถูกมอบให้กับรายการสั่งซื้อแล้ว จะมีการอ้างอิงไปยัง OrderItem
+	OrderItemID *uint      `json:"order_item_id"`
+	OrderItem   *OrderItem `gorm:"foreignKey:OrderItemID" json:"order_item,omitempty"`
 }

--- a/frontend/src/interfaces/KeyGame.ts
+++ b/frontend/src/interfaces/KeyGame.ts
@@ -1,0 +1,17 @@
+// src/interfaces/KeyGame.ts
+import type { Game } from "./Game";
+import type { OrderItem } from "./OrderItem";
+
+export interface KeyGame {
+  ID: number;
+  key: string;
+  game_id: number;
+  game?: Game;
+  order_item_id?: number | null;
+  order_item?: OrderItem;
+}
+
+export interface CreateKeyGameRequest {
+  key?: string;
+  game_id: number;
+}

--- a/frontend/src/interfaces/OrderItem.ts
+++ b/frontend/src/interfaces/OrderItem.ts
@@ -1,0 +1,32 @@
+// src/interfaces/OrderItem.ts
+import type { KeyGame } from "./KeyGame";
+
+export interface OrderItem {
+  ID: number;
+  unit_price: number;
+  qty: number;
+  line_discount: number;
+  line_total: number;
+  order_id: number;
+  game_key_id?: number | null;
+  key_game?: KeyGame;
+}
+
+export interface CreateOrderItemRequest {
+  unit_price: number;
+  qty: number;
+  line_discount: number;
+  line_total: number;
+  order_id: number;
+  game_key_id?: number | null;
+}
+
+export interface UpdateOrderItemRequest {
+  ID: number;
+  unit_price?: number;
+  qty?: number;
+  line_discount?: number;
+  line_total?: number;
+  order_id?: number;
+  game_key_id?: number | null;
+}

--- a/frontend/src/interfaces/index.ts
+++ b/frontend/src/interfaces/index.ts
@@ -7,3 +7,5 @@ export * from "./Reaction";
 export * from "./Attachment";
 export * from "./Notification";
 export * from "./UserGame";
+export * from "./OrderItem";
+export * from "./KeyGame";


### PR DESCRIPTION
## Summary
- extend KeyGame entity with Game and OrderItem references
- add CRUD controller for managing game keys
- introduce KeyGame and OrderItem interfaces for the frontend

## Testing
- `go vet -v ./...` *(hangs while enumerating packages; interrupted)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcd25d53988322bd7403e940cf266b