### PR TITLE
feat: add login and signup modal

### DIFF
--- a/frontend/src/components/AuthModal.tsx
+++ b/frontend/src/components/AuthModal.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Modal, Form, Input, Button, DatePicker } from 'antd';
+
+interface AuthModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const AuthModal: React.FC<AuthModalProps> = ({ open, onClose }) => {
+  const [isLogin, setIsLogin] = useState(true);
+
+  const toggleMode = () => setIsLogin(!isLogin);
+
+  return (
+    <Modal open={open} onCancel={onClose} footer={null} centered>
+      {isLogin ? (
+        <>
+          <h2 style={{ textAlign: 'center', marginBottom: 24 }}>Login</h2>
+          <Form layout="vertical">
+            <Form.Item
+              label="Username"
+              name="username"
+              rules={[{ required: true, message: 'Please enter your username' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Password"
+              name="password"
+              rules={[{ required: true, message: 'Please enter your password' }]}
+            >
+              <Input.Password />
+            </Form.Item>
+            <Form.Item>
+              <Button type="primary" htmlType="submit" block>
+                Login
+              </Button>
+            </Form.Item>
+            <Form.Item>
+              <Button type="link" onClick={toggleMode} block>
+                Don't have an account? Sign Up
+              </Button>
+            </Form.Item>
+          </Form>
+        </>
+      ) : (
+        <>
+          <h2 style={{ textAlign: 'center', marginBottom: 24 }}>Sign Up</h2>
+          <Form layout="vertical">
+            <Form.Item
+              label="Username"
+              name="username"
+              rules={[{ required: true, message: 'Please enter your username' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Password"
+              name="password"
+              rules={[{ required: true, message: 'Please enter your password' }]}
+            >
+              <Input.Password />
+            </Form.Item>
+            <Form.Item
+              label="Email"
+              name="email"
+              rules={[{ required: true, type: 'email', message: 'Please enter a valid email' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="First Name"
+              name="first_name"
+              rules={[{ required: true, message: 'Please enter your first name' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Last Name"
+              name="last_name"
+              rules={[{ required: true, message: 'Please enter your last name' }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Birthday"
+              name="birthday"
+              rules={[{ required: true, message: 'Please select your birthday' }]}
+            >
+              <DatePicker style={{ width: '100%' }} />
+            </Form.Item>
+            <Form.Item>
+              <Button type="primary" htmlType="submit" block>
+                Sign Up
+              </Button>
+            </Form.Item>
+            <Form.Item>
+              <Button type="link" onClick={toggleMode} block>
+                Already have an account? Login
+              </Button>
+            </Form.Item>
+          </Form>
+        </>
+      )}
+    </Modal>
+  );
+};
+
+export default AuthModal;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,10 +1,26 @@
-import { Input, Avatar, Space } from 'antd';
-import { SearchOutlined, ShoppingCartOutlined, BellOutlined, DollarCircleOutlined } from '@ant-design/icons';
+import { useState } from 'react';
+import { Input, Avatar, Space, Button } from 'antd';
+import {
+  SearchOutlined,
+  ShoppingCartOutlined,
+  BellOutlined,
+  DollarCircleOutlined,
+} from '@ant-design/icons';
 import { Link } from 'react-router-dom';
+import AuthModal from './AuthModal';
 
 const Navbar = () => {
+  const [openAuth, setOpenAuth] = useState(false);
+
   return (
-    <div style={{ display: 'flex', justifyContent: 'space-between', padding: '16px', background: '#1f1f1f' }}>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        padding: '16px',
+        background: '#1f1f1f',
+      }}
+    >
       {/* Search */}
       <Input
         prefix={<SearchOutlined />}
@@ -22,8 +38,12 @@ const Navbar = () => {
         </Link>
 
         <ShoppingCartOutlined style={{ color: 'white', fontSize: '18px' }} />
+        <Button type="primary" onClick={() => setOpenAuth(true)}>
+          Login
+        </Button>
         <Avatar src="https://i.pravatar.cc/300" />
       </Space>
+      <AuthModal open={openAuth} onClose={() => setOpenAuth(false)} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add login modal with signup form
- hook navbar login button to modal

## Testing
- `npm run lint` *(fails: DownloadOutlined is defined but never used, and others)*
- `npm run build` *(fails: PictureOutlined is declared but its value is never read, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfcadd3988322a5f30d1828190d00