### PR TITLE
feat: add auth context with login/logout state

### DIFF
--- a/frontend/src/components/AuthModal.tsx
+++ b/frontend/src/components/AuthModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Modal, Form, Input, Button, DatePicker } from 'antd';
+import { useAuth } from '../context/AuthContext';
 
 interface AuthModalProps {
   open: boolean;
@@ -8,6 +9,7 @@ interface AuthModalProps {
 
 const AuthModal: React.FC<AuthModalProps> = ({ open, onClose }) => {
   const [isLogin, setIsLogin] = useState(true);
+  const { login } = useAuth();
 
   const toggleMode = () => setIsLogin(!isLogin);
 
@@ -27,7 +29,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ open, onClose }) => {
       }
 
       const data = await res.json();
-      localStorage.setItem('token', data.token);
+      login(data.token, values.username);
       onClose();
     } catch (error) {
       console.error(error);
@@ -52,7 +54,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ open, onClose }) => {
       }
 
       const data = await res.json();
-      localStorage.setItem('token', data.token);
+      login(data.token, values.username);
       onClose();
     } catch (error) {
       console.error(error);

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -2,12 +2,14 @@
 import { SearchOutlined, ShoppingCartOutlined, BellOutlined, DollarCircleOutlined } from '@ant-design/icons';
 import { useState } from 'react';
 import { Input, Avatar, Space, Button } from 'antd';
+import { useAuth } from '../context/AuthContext';
 
 import { Link } from 'react-router-dom';
 import AuthModal from '../components/AuthModal';
 
 const Navbar = () => {
   const [openAuth, setOpenAuth] = useState(false);
+  const { token, username, logout } = useAuth();
 
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', padding: '16px', background: '#1f1f1f' }}>
@@ -36,10 +38,17 @@ const Navbar = () => {
         </Link>
 
         <ShoppingCartOutlined style={{ color: 'white', fontSize: '18px' }} />
-        <Button type="primary" onClick={() => setOpenAuth(true)}>
-          Login
-        </Button>
-        <Avatar src="https://i.pravatar.cc/300" />
+        {token ? (
+          <>
+            <span style={{ color: 'white' }}>{username}</span>
+            <Button onClick={logout}>Logout</Button>
+            <Avatar src="https://i.pravatar.cc/300" />
+          </>
+        ) : (
+          <Button type="primary" onClick={() => setOpenAuth(true)}>
+            Login
+          </Button>
+        )}
       </Space>
       <AuthModal open={openAuth} onClose={() => setOpenAuth(false)} />
     </div>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,45 @@
+import { createContext, useState, useContext } from 'react';
+import type { ReactNode } from 'react';
+
+interface AuthContextType {
+  token: string | null;
+  username: string | null;
+  login: (token: string, username: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  token: null,
+  username: null,
+  login: () => {},
+  logout: () => {},
+});
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
+  const [username, setUsername] = useState<string | null>(localStorage.getItem('username'));
+
+  const login = (newToken: string, name: string) => {
+    setToken(newToken);
+    setUsername(name);
+    localStorage.setItem('token', newToken);
+    localStorage.setItem('username', name);
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUsername(null);
+    localStorage.removeItem('token');
+    localStorage.removeItem('username');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, username, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);
+
+export default AuthContext;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,9 +6,12 @@ import router from "./routes/text.tsx"
 import {
   RouterProvider,
 } from "react-router-dom";
+import { AuthProvider } from './context/AuthContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </StrictMode>
 )


### PR DESCRIPTION
## Summary
- create AuthContext to store token and username with login/logout helpers
- wrap RouterProvider with AuthProvider to expose auth state
- update AuthModal to update auth context after login/signup
- show username with logout in Navbar when authenticated

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 27 errors, 2 warnings)*
- `npm run build` *(fails: TypeScript errors in existing files)*


------
https://chatgpt.com/codex/tasks/task_e_68bd0a5cbfe483229503d7657a87bf23