### PR TITLE
Handle date-only birthday during user creation

### DIFF
--- a/backend/controllers/users.go
+++ b/backend/controllers/users.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"net/http"
+	"time"
 
 	"example.com/sa-gameshop/configs"
 	"example.com/sa-gameshop/entity"
@@ -11,10 +12,34 @@ import (
 
 // POST /users
 func CreateUser(c *gin.Context) {
-	var body entity.User
-	if err := c.ShouldBindJSON(&body); err != nil {
+	var req struct {
+		Username  string `json:"username"`
+		Password  string `json:"password"`
+		Email     string `json:"email"`
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		Birthday  string `json:"birthday"`
+		RoleID    uint   `json:"role_id"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request body"})
 		return
+	}
+
+	birthday, err := time.Parse("2006-01-02", req.Birthday)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid birthday format"})
+		return
+	}
+
+	body := entity.User{
+		Username:  req.Username,
+		Password:  req.Password,
+		Email:     req.Email,
+		FirstName: req.FirstName,
+		LastName:  req.LastName,
+		Birthday:  birthday,
+		RoleID:    req.RoleID,
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(body.Password), bcrypt.DefaultCost)


### PR DESCRIPTION
## Summary
- parse `YYYY-MM-DD` birthday strings into `time.Time` when creating users

## Testing
- `go test ./...` *(fails: missing go.sum entry for github.com/golang-jwt/jwt/v5)*
- `go mod tidy` *(fails: downloading github.com/golang-jwt/jwt/v5: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0f89329083228d110f1932d1fe99