### PR TITLE
feat: add payment approval and rejection

### DIFF
--- a/backend/configs/db.go
+++ b/backend/configs/db.go
@@ -52,6 +52,9 @@ func SetupDatabase() {
 		&entity.Reaction{},
 		&entity.Attachment{},
 		&entity.Notification{},
+		&entity.Order{},
+		&entity.Payment{},
+		&entity.PaymentSlip{},
 	); err != nil {
 		log.Fatal("auto migrate failed: ", err)
 	}

--- a/backend/entity/payment.go
+++ b/backend/entity/payment.go
@@ -9,9 +9,10 @@ import (
 
 type Payment struct {
 	gorm.Model
-	PaymentDate time.Time `json:"payment_date"`
-	Status      string    `json:"status"`
-	Amount      float64   `json:"amount"`
+	PaymentDate  time.Time `json:"payment_date"`
+	Status       string    `json:"status"`
+	Amount       float64   `json:"amount"`
+	RejectReason string    `json:"reject_reason"`
 
 	OrderID uint   `json:"order_id"`
 	Order   *Order `gorm:"foreignKey:OrderID" json:"order,omitempty"`

--- a/backend/main.go
+++ b/backend/main.go
@@ -109,6 +109,14 @@ func main() {
 		router.POST("/new-minimumspec", controllers.CreateMinimumSpec)
 		router.GET("/minimumspec", controllers.FindMinimumSpec)
 
+		// ===== Payments =====
+		router.POST("/payments", controllers.CreatePayment)
+		router.GET("/payments", controllers.FindPayments)
+		router.PATCH("/payments/:id", controllers.UpdatePayment)
+		router.DELETE("/payments/:id", controllers.DeletePayment)
+		router.POST("/payments/:id/approve", controllers.ApprovePayment)
+		router.POST("/payments/:id/reject", controllers.RejectPayment)
+
 	}
 
 	// Run the server


### PR DESCRIPTION
## Summary
- add RejectReason field to payments
- allow admins to approve or reject payments with JWT-based authorization
- expose payment endpoints in router and migrate related tables

## Testing
- `cd backend && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bd56dcd74483229cb6781d11960942