### PR TITLE
feat: support thread sorting

### DIFF
--- a/frontend/src/pages/Community/CommunityPage.tsx
+++ b/frontend/src/pages/Community/CommunityPage.tsx
@@ -1,8 +1,11 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { message, Space, Select } from "antd";
+import axios from "axios";
 import ThreadList from "./ThreadList";
 import ThreadDetail from "./ThreadDetail";
 import type { Thread, ThreadComment } from "./types";
+
+const base_url = "http://localhost:8088";
 
 export default function CommunityPage() {
   // --- mock data เริ่มต้น ---
@@ -14,6 +17,7 @@ export default function CommunityPage() {
       author: "neurougue",
       createdAt: "3 ชม.ที่แล้ว",
       likes: 2,
+      commentCount: 2,
       comments: [
         { id: 11, author: "Yanis_zaky", content: "1", datetime: "3 ชม. @ 8:17am" },
         { id: 12, author: "MaT", content: "2", datetime: "3 ชม. @ 5:06pm" },
@@ -26,6 +30,7 @@ export default function CommunityPage() {
       author: "Sil Halcorrn",
       createdAt: "8 ชม.ที่แล้ว",
       likes: 1,
+      commentCount: 0,
       comments: [],
     },
   ]);
@@ -51,6 +56,7 @@ export default function CommunityPage() {
       author: "คุณ",
       createdAt: "เพิ่งโพสต์",
       likes: 0,
+      commentCount: 0,
       comments: [],
       images, // ✅ เก็บรูปไปกับเธรด
     };
@@ -68,10 +74,33 @@ export default function CommunityPage() {
       datetime: "เพิ่งตอบกลับ",
     };
     setThreads((prev) =>
-      prev.map((t) => (t.id === activeThread.id ? { ...t, comments: [...t.comments, newC] } : t))
+      prev.map((t) =>
+        t.id === activeThread.id
+          ? { ...t, comments: [...t.comments, newC], commentCount: t.commentCount + 1 }
+          : t
+      )
     );
     message.success("ตอบกลับแล้ว");
   };
+
+  useEffect(() => {
+    axios
+      .get(`${base_url}/threads`, { params: { sort: sortBy } })
+      .then((res) => {
+        const data = res.data.map((t: any) => ({
+          id: t.ID,
+          title: t.title,
+          body: t.content,
+          author: t.user?.username || "",
+          createdAt: t.CreatedAt || "",
+          likes: t.likes,
+          commentCount: t.comments,
+          comments: [],
+        })) as Thread[];
+        setThreads(data);
+      })
+      .catch(() => {});
+  }, [sortBy]);
 
   return (
     <div style={{minHeight:'100vh', padding: 24 , flex: 1 , background: "#1e1e2f"}}>

--- a/frontend/src/pages/Community/ThreadList.tsx
+++ b/frontend/src/pages/Community/ThreadList.tsx
@@ -46,7 +46,7 @@ export default function ThreadList({ threads, sortBy, onOpen, onCreate }: Props)
     return arr.sort((a, b) => {
       if (sortBy === "likes") return b.likes - a.likes;
       if (sortBy === "comments")
-        return b.comments.length - a.comments.length;
+        return b.commentCount - a.commentCount;
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
   }, [threads, sortBy]);
@@ -153,7 +153,7 @@ export default function ThreadList({ threads, sortBy, onOpen, onCreate }: Props)
               </div>
               <Space>
                 <Button icon={<LikeOutlined />} shape="circle" />
-                <Badge count={t.comments.length} size="small">
+                <Badge count={t.commentCount} size="small">
                   <Button icon={<MessageOutlined />} shape="circle" />
                 </Badge>
               </Space>

--- a/frontend/src/pages/Community/types.ts
+++ b/frontend/src/pages/Community/types.ts
@@ -14,7 +14,8 @@ export type Thread = {
   author: string;
   createdAt: string;
   likes: number;
-  comments: ThreadComment[];
+  commentCount: number;
+  comments?: ThreadComment[];
   images?: string[];           // ✅ แนบรูปในเธรด
 };
 


### PR DESCRIPTION
## Summary
- add comment and like aggregation to thread listing with sort options
- expose counts and support sort parameter in frontend community page

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 29 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6b688f7c832293de59555aebfb08