### PR TITLE
Add order routes to API router

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -109,6 +109,13 @@ func main() {
 		router.POST("/new-minimumspec", controllers.CreateMinimumSpec)
 		router.GET("/minimumspec", controllers.FindMinimumSpec)
 
+		// ===== Orders =====
+		router.POST("/orders", controllers.CreateOrder)
+		router.GET("/orders", controllers.FindOrders)
+		router.GET("/orders/:id", controllers.FindOrderByID)
+		router.PUT("/orders/:id", controllers.UpdateOrder)
+		router.DELETE("/orders/:id", controllers.DeleteOrder)
+
 		// ===== Payments =====
 		router.POST("/payments", controllers.CreatePayment)
 		router.GET("/payments", controllers.FindPayments)


### PR DESCRIPTION
## Summary
- expose CRUD order endpoints in main router

## Testing
- `go test ./...` *(fails: command hung, interrupted)*
- `go run main.go` *(fails: command hung during startup)*

------
https://chatgpt.com/codex/tasks/task_e_68bd82945cd48322bf8c239c14f0d480