### PR TITLE
feat: include order id in payment url

### DIFF
--- a/frontend/src/components/Payment.tsx
+++ b/frontend/src/components/Payment.tsx
@@ -45,7 +45,11 @@ const PaymentPage = () => {
   const [submitting, setSubmitting] = useState(false);
   const { id } = useParams();
   const [searchParams] = useSearchParams();
-  const orderIdParam = id || searchParams.get("id") || searchParams.get("order_id");
+  const orderIdParam =
+    id ||
+    searchParams.get("id") ||
+    searchParams.get("order_id") ||
+    localStorage.getItem("orderId");
 
   useEffect(() => {
     if (!orderIdParam) return;

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -70,8 +70,10 @@ const ProductGrid = () => {
       const orderId = res.data.ID || res.data.id;
       if (orderId) {
         localStorage.setItem('orderId', String(orderId));
+        navigate(`/category/Payment?id=${orderId}`);
+      } else {
+        navigate('/category/Payment');
       }
-      navigate('/category/Payment');
     } catch (err) {
       console.error('add to cart error', err);
     }


### PR DESCRIPTION
## Summary
- pass order id in navigate to Payment
- fallback to localStorage for order id retrieval

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run build` *(fails: TypeScript errors across pages)*


------
https://chatgpt.com/codex/tasks/task_e_68bd885004588322b1f6e18a20847275