### PR TITLE
Ensure game data loads with order items

### DIFF
--- a/backend/controllers/order.go
+++ b/backend/controllers/order.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"example.com/sa-gameshop/configs"
-    "example.com/sa-gameshop/entity"
+	"example.com/sa-gameshop/entity"
 	"github.com/gin-gonic/gin"
 )
 
@@ -53,7 +53,7 @@ func FindOrderByID(c *gin.Context) {
 	var row entity.Order
 	if tx := configs.DB().
 		Preload("User").
-		Preload("OrderItems.GameKey").
+		Preload("OrderItems.KeyGame.Game").
 		Preload("Payments.PaymentSlips").
 		Preload("OrderPromotions.Promotion").
 		First(&row, c.Param("id")); tx.RowsAffected == 0 {


### PR DESCRIPTION
## Summary
- Load associated game when fetching orders to include game info in order items

## Testing
- `go test ./...` *(fails: command produced no output; environment issue)*
- `curl localhost:8088/orders/1` *(fails: connection refused, server could not start)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8d38e4d08322a4ade8f197888db9