### PR TITLE
Render order items in Payment component

### DIFF
--- a/frontend/src/components/Payment.tsx
+++ b/frontend/src/components/Payment.tsx
@@ -28,7 +28,7 @@ const TEXT_SUB = "#a9afc3";
 import qrPromptPay from "../assets/ktb-qr.png";
 
 interface CartItem {
-  id: string;
+  id: number;
   title: string;
   price: number; // THB
   note?: string;
@@ -61,9 +61,9 @@ const PaymentPage = () => {
         setOrder(data);
         const mapped: CartItem[] =
           data.order_items?.map((it: any) => ({
-            id: String(it.id),
-            title: it.key_game?.game?.game_name || `Game ${it.id}`,
-            price: it.line_total ?? it.unit_price ?? 0,
+            id: it.id,
+            title: it.key_game.game.game_name,
+            price: it.line_total,
           })) || [];
         setItems(mapped);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Map fetched order items to include id, title and price for each game
- Render each order item with its title and price on the payment page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 33 problems (32 errors, 1 warning))*

------
https://chatgpt.com/codex/tasks/task_e_68bd8edefc58832281e0b16b9ca66c6b