### PR TITLE
Refactor PromotionManager to use shared Promotion interfaces

### DIFF
--- a/frontend/src/interfaces/Promotion.ts
+++ b/frontend/src/interfaces/Promotion.ts
@@ -6,6 +6,8 @@ export type DiscountType = "PERCENT" | "AMOUNT";
 
 export interface Promotion {
   ID: number;
+  title: string;
+  description?: string;
   discount_type: DiscountType;
   discount_value: number;        // >= 0
   start_date: string;            // ISO string
@@ -18,6 +20,8 @@ export interface Promotion {
 }
 
 export interface CreatePromotionRequest {
+  title: string;
+  description?: string;
   discount_type: DiscountType;
   discount_value: number;
   start_date: string;   // e.g., new Date().toISOString()
@@ -28,4 +32,4 @@ export interface CreatePromotionRequest {
   game_ids?: number[];
 }
 
-export interface UpdatePromotionRequest extends Partial<CreatePromotionRequest> {}
+export type UpdatePromotionRequest = Partial<CreatePromotionRequest>;


### PR DESCRIPTION
## Summary
- expand promotion interfaces with title/description fields
- refactor PromotionManager form and state to use discount_type, discount_value, status
- convert form values to CreatePromotionRequest/UpdatePromotionRequest before sending

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_68bd8e9ae2408329ad56b877e5a63c54