### PR TITLE
feat: track user id in auth context and order creation

### DIFF
--- a/frontend/src/components/AuthModal.tsx
+++ b/frontend/src/components/AuthModal.tsx
@@ -32,7 +32,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ open, onClose, onLoginSuccess }) 
         return;
       }
 
-      login(result.token, values.username);
+      await login(result.token, values.username);
       const notification = {
         ID: Date.now(),
         title: 'ระบบ',
@@ -66,7 +66,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ open, onClose, onLoginSuccess }) 
       }
 
       const data = await res.json();
-      login(data.token, values.username);
+      await login(data.token, values.username);
       onClose();
     } catch (error) {
       console.error(error);

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -12,7 +12,7 @@ import type { Notification } from '../interfaces/Notification';
 const Navbar = () => {
   const [openAuth, setOpenAuth] = useState(false);
   const [notifications, setNotifications] = useState<Notification[]>([]);
-  const { token, username, logout } = useAuth();
+  const { token, username, logout, userId } = useAuth();
 
   const handleLoginSuccess = () => {
     setNotifications((prev) => [
@@ -22,7 +22,7 @@ const Navbar = () => {
         title: 'Login Successful',
         message: 'You have logged in successfully',
         type: 'system',
-        user_id: 0,
+        user_id: userId ?? 0,
       },
     ]);
   };

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -7,7 +7,11 @@ import axios from 'axios';
 
 const base_url = 'http://localhost:8088';
 
-const ProductGrid = () => {
+interface ProductGridProps {
+  userId: number | null;
+}
+
+const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
   interface Game {
       ID: number;
       game_name: string;
@@ -59,7 +63,7 @@ const ProductGrid = () => {
       // 2) ถ้ายังไม่มี ให้สร้างออเดอร์ใหม่แล้วเก็บ orderId
       if (!orderId) {
         const orderRes = await axios.post(`${base_url}/orders`, {
-          user_id: 1,
+          user_id: userId,
           total_amount: 0,
           order_status: 'PENDING',
         });

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -4,37 +4,61 @@ import type { ReactNode } from 'react';
 interface AuthContextType {
   token: string | null;
   username: string | null;
-  login: (token: string, username: string) => void;
+  userId: number | null;
+  login: (token: string, username: string) => Promise<void>;
   logout: () => void;
 }
 
 const AuthContext = createContext<AuthContextType>({
   token: null,
   username: null,
-  login: () => {},
+  userId: null,
+  login: async () => {},
   logout: () => {},
 });
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
   const [username, setUsername] = useState<string | null>(localStorage.getItem('username'));
+  const [userId, setUserId] = useState<number | null>(() => {
+    const stored = localStorage.getItem('userId');
+    return stored ? Number(stored) : null;
+  });
 
-  const login = (newToken: string, name: string) => {
+  const login = async (newToken: string, name: string) => {
     setToken(newToken);
     setUsername(name);
     localStorage.setItem('token', newToken);
     localStorage.setItem('username', name);
+
+    try {
+      const res = await fetch('http://localhost:8088/users/me', {
+        headers: {
+          Authorization: `Bearer ${newToken}`,
+        },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const id = data.ID ?? data.id;
+        setUserId(id);
+        localStorage.setItem('userId', String(id));
+      }
+    } catch (err) {
+      console.error('Failed to fetch user info', err);
+    }
   };
 
   const logout = () => {
     setToken(null);
     setUsername(null);
+    setUserId(null);
     localStorage.removeItem('token');
     localStorage.removeItem('username');
+    localStorage.removeItem('userId');
   };
 
   return (
-    <AuthContext.Provider value={{ token, username, login, logout }}>
+    <AuthContext.Provider value={{ token, username, userId, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,10 +1,12 @@
 import Navbar from "../components/Navbar";
 import ProductGrid from "../components/ProductGrid";
+import { useAuth } from "../context/AuthContext";
 import { Button, Space, Typography } from "antd";
 
 const { Title } = Typography;
 
 const Home = () => {
+  const { userId } = useAuth();
   return (
     <div style={{ background: '#141414', flex: 1 , minHeight: '100vh'}}>
       <Navbar />
@@ -17,7 +19,7 @@ const Home = () => {
           <Button shape="round">Recommended</Button>
           <Button shape="round">Filter</Button>
         </Space>
-        <ProductGrid />
+        <ProductGrid userId={userId} />
       </div>
     </div>
   );

--- a/frontend/src/pages/Review/Mygame.tsx
+++ b/frontend/src/pages/Review/Mygame.tsx
@@ -1,11 +1,13 @@
 import { Layout, Space, Typography } from "antd";
 import Sidebar from "../../components/Sidebar";
 import ProductGrid from "../../components/ProductGrid"; // ใช้คอมโพเนนต์ที่มีอยู่จริง
+import { useAuth } from "../../context/AuthContext";
 
 const { Content } = Layout;
 const { Title } = Typography;
 
 const Mygame = () => {
+  const { userId } = useAuth();
   return (
     <Layout style={{ minHeight: "100vh", background: "#0f0f0f" }}>
       {/* Sidebar ทางซ้าย */}
@@ -31,7 +33,7 @@ const Mygame = () => {
           </Space>
 
           {/* UI-only: แสดงกริดเกมจากคอมโพเนนต์ที่มีอยู่แล้ว */}
-          <ProductGrid />
+          <ProductGrid userId={userId} />
         </div>
       </Content>
     </Layout>


### PR DESCRIPTION
## Summary
- add userId to AuthContext and fetch current user after login
- pass userId through Home/Mygame into ProductGrid
- use context userId when creating orders and notifications

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68be89500e6c8322b7657fe7bff39b4f