### PR TITLE
chore: configure promotions API URL

### DIFF
--- a/frontend/src/services/promotions.ts
+++ b/frontend/src/services/promotions.ts
@@ -5,7 +5,7 @@ import type {
 } from "../interfaces/Promotion";
 import type { Game } from "../interfaces/Game";
 
-const API_URL = import.meta.env.VITE_API_URL as string;
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8088";
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- fallback to localhost if VITE_API_URL is undefined
- ensure promotion service functions use shared API_URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 34 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68be98bc76e483299793e0f7b9e54077