### PR TITLE
fix: update game API path

### DIFF
--- a/frontend/src/services/promotions.ts
+++ b/frontend/src/services/promotions.ts
@@ -56,7 +56,7 @@ export async function deletePromotion(id: number): Promise<void> {
 }
 
 export async function listGames(): Promise<Game[]> {
-  const res = await fetch(`${API_URL}/games`);
+  const res = await fetch(`${API_URL}/game`);
   return handleResponse<Game[]>(res);
 }
 


### PR DESCRIPTION
## Summary
- correct promotions service to use `/game` endpoint when listing games

## Testing
- `npx eslint src/services/promotions.ts`
- `curl -v http://localhost:8088/game` *(fails: connection refused, backend build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68be9ab0b5848329bfc60019fed894cf