### PR TITLE
feat: load promotion detail from API

### DIFF
--- a/frontend/src/services/promotions.ts
+++ b/frontend/src/services/promotions.ts
@@ -22,6 +22,16 @@ export async function listPromotions(withGames = false): Promise<Promotion[]> {
   return handleResponse<Promotion[]>(res);
 }
 
+export async function getPromotion(
+  id: number,
+  withGames = false,
+): Promise<Promotion> {
+  const url = new URL(`${API_URL}/promotions/${id}`);
+  if (withGames) url.searchParams.set("with", "games");
+  const res = await fetch(url.toString());
+  return handleResponse<Promotion>(res);
+}
+
 export async function createPromotion(
   payload: CreatePromotionRequest,
 ): Promise<Promotion> {


### PR DESCRIPTION
## Summary
- replace PromotionDetail mock data with API fetching
- add getPromotion helper in promotions service

## Testing
- `npm run lint` *(fails: command not found: npm)*
- `npm run build` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68be9cf06eac832993506b9344385aef