### PR TITLE
Enforce login before creating orders

### DIFF
--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -56,6 +56,10 @@ const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
   }, []);
 
   const handleAddToCart = async (g: Game) => {
+    if (!userId) {
+      alert('Please log in to continue');
+      return;
+    }
     try {
       // 1) ตรวจสอบว่ามี orderId ใน localStorage หรือไม่
       let orderId = localStorage.getItem('orderId');

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -40,8 +40,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       if (res.ok) {
         const data = await res.json();
         const id = data.ID ?? data.id;
-        setUserId(id);
-        localStorage.setItem('userId', String(id));
+        if (typeof id === 'number') {
+          setUserId(id);
+          localStorage.setItem('userId', String(id));
+        } else {
+          console.warn('Invalid user ID received', data);
+        }
       }
     } catch (err) {
       console.error('Failed to fetch user info', err);


### PR DESCRIPTION
## Summary
- prevent add-to-cart when no user is logged in
- validate and store numeric `userId` during login

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 37 errors, 1 warning)


------
https://chatgpt.com/codex/tasks/task_e_68bea5baea08832298275e873abd4dc1