### PR TITLE
Return user ID during login and store in frontend auth state

### DIFF
--- a/backend/controllers/auth.go
+++ b/backend/controllers/auth.go
@@ -50,5 +50,9 @@ func Login(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "login successful", "token": tokenString})
+       c.JSON(http.StatusOK, gin.H{
+               "message": "login successful",
+               "token":   tokenString,
+               "user_id": user.ID,
+       })
 }

--- a/frontend/src/components/AuthModal.tsx
+++ b/frontend/src/components/AuthModal.tsx
@@ -32,7 +32,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ open, onClose, onLoginSuccess }) 
         return;
       }
 
-      await login(result.token, values.username);
+      await login(result.token, values.username, result.user_id);
       const notification = {
         ID: Date.now(),
         title: 'ระบบ',
@@ -66,7 +66,10 @@ const AuthModal: React.FC<AuthModalProps> = ({ open, onClose, onLoginSuccess }) 
       }
 
       const data = await res.json();
-      await login(data.token, values.username);
+      // Optionally log the user in immediately if a token is returned
+      if (data.token && data.ID) {
+        await login(data.token, values.username, data.ID);
+      }
       onClose();
     } catch (error) {
       console.error(error);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -5,7 +5,7 @@ interface AuthContextType {
   token: string | null;
   username: string | null;
   userId: number | null;
-  login: (token: string, username: string) => Promise<void>;
+  login: (token: string, username: string, userId: number) => Promise<void>;
   logout: () => void;
 }
 
@@ -25,31 +25,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return stored ? Number(stored) : null;
   });
 
-  const login = async (newToken: string, name: string) => {
+  const login = async (newToken: string, name: string, id: number) => {
     setToken(newToken);
     setUsername(name);
+    setUserId(id);
     localStorage.setItem('token', newToken);
     localStorage.setItem('username', name);
-
-    try {
-      const res = await fetch('http://localhost:8088/users/me', {
-        headers: {
-          Authorization: `Bearer ${newToken}`,
-        },
-      });
-      if (res.ok) {
-        const data = await res.json();
-        const id = data.ID ?? data.id;
-        if (typeof id === 'number') {
-          setUserId(id);
-          localStorage.setItem('userId', String(id));
-        } else {
-          console.warn('Invalid user ID received', data);
-        }
-      }
-    } catch (err) {
-      console.error('Failed to fetch user info', err);
-    }
+    localStorage.setItem('userId', String(id));
   };
 
   const logout = () => {


### PR DESCRIPTION
## Summary
- Return `user_id` in backend login response
- Simplify frontend auth context to store user ID from login
- Pass user ID from login modal to auth context

## Testing
- `go test ./...` *(no tests found)*
- `curl -s -X POST http://localhost:8088/login -H 'Content-Type: application/json' -d '{"username":"testuser","password":"pass"}'`
- `npm test` *(missing script: test)*
- `npm run lint` *(errors: Unexpected any, unused vars, etc.)*
- `npm run build` *(TS compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68beaa56f10883228a1f90ff75cde3bd