### PR TITLE
feat: support promotion image uploads

### DIFF
--- a/frontend/src/services/promotions.ts
+++ b/frontend/src/services/promotions.ts
@@ -1,8 +1,4 @@
-import type {
-  Promotion,
-  CreatePromotionRequest,
-  UpdatePromotionRequest,
-} from "../interfaces/Promotion";
+import type { Promotion } from "../interfaces/Promotion";
 import type { Game } from "../interfaces/Game";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8088";
@@ -32,25 +28,21 @@ export async function getPromotion(
   return handleResponse<Promotion>(res);
 }
 
-export async function createPromotion(
-  payload: CreatePromotionRequest,
-): Promise<Promotion> {
+export async function createPromotion(payload: FormData): Promise<Promotion> {
   const res = await fetch(`${API_URL}/promotions`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
+    body: payload,
   });
   return handleResponse<Promotion>(res);
 }
 
 export async function updatePromotion(
   id: number,
-  payload: UpdatePromotionRequest,
+  payload: FormData,
 ): Promise<Promotion> {
   const res = await fetch(`${API_URL}/promotions/${id}`, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
+    body: payload,
   });
   return handleResponse<Promotion>(res);
 }


### PR DESCRIPTION
## Summary
- allow selecting promotion image files in manager page
- send promotion data as `FormData` for create/update
- accept multipart uploads on backend and save promo images

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors)
- `GOFLAGS=-mod=vendor go test ./...` (fails: directory prefix . does not contain main module or its selected dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68beaae835dc8329a611bf0975ef198d