### PR TITLE
Clear invalid order references for new sessions

### DIFF
--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -71,7 +71,9 @@ const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
         } catch (error) {
           if (
             axios.isAxiosError(error) &&
-            (error.response?.status === 404 || error.response?.status === 400)
+            (error.response?.status === 404 ||
+              error.response?.status === 400 ||
+              error.response?.status === 403)
           ) {
             // ถ้าออเดอร์ไม่พบหรือไม่ถูกต้อง ให้ลบ orderId และสร้างใหม่
             localStorage.removeItem('orderId');

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -41,6 +41,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     localStorage.removeItem('token');
     localStorage.removeItem('username');
     localStorage.removeItem('userId');
+    localStorage.removeItem('orderId');
   };
 
   return (


### PR DESCRIPTION
## Summary
- clear stored order ID on logout
- treat 403 when checking existing order as invalid and create a new order

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 37 errors)

------
https://chatgpt.com/codex/tasks/task_e_68bebebd577483229bcfa87a2fdfa244