### PR TITLE
Compute discount for order items

### DIFF
--- a/backend/controllers/order_item.go
+++ b/backend/controllers/order_item.go
@@ -3,14 +3,25 @@ package controllers
 import (
 	"math"
 	"net/http"
+	"time"
 
 	"example.com/sa-gameshop/configs"
 	"example.com/sa-gameshop/entity"
 	"github.com/gin-gonic/gin"
 )
 
+// payload สำหรับสร้าง OrderItem โดยไม่ให้ผู้ใช้กำหนดส่วนลดเอง
+type createOrderItemRequest struct {
+	UnitPrice    float64  `json:"unit_price" binding:"required"`
+	QTY          int      `json:"qty" binding:"required"`
+	OrderID      uint     `json:"order_id" binding:"required"`
+	GameKeyID    *uint    `json:"game_key_id"`
+	LineDiscount *float64 `json:"line_discount"`
+	LineTotal    *float64 `json:"line_total"`
+}
+
 func CreateOrderItem(c *gin.Context) {
-	var body entity.OrderItem
+	var body createOrderItemRequest
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
 		return
@@ -25,6 +36,7 @@ func CreateOrderItem(c *gin.Context) {
 	}
 
 	// ตรวจ GameKey (ถ้าระบุ)
+	var gameID uint
 	if body.GameKeyID != nil {
 		var gk entity.KeyGame
 		if tx := db.First(&gk, *body.GameKeyID); tx.RowsAffected == 0 {
@@ -40,17 +52,66 @@ func CreateOrderItem(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "game key already assigned"})
 			return
 		}
+		gameID = gk.GameID
 	}
 
-	// คำนวณ line total แบบง่าย
+	// หาส่วนลดจากโปรโมชั่นที่ผูกกับเกมหรือออร์เดอร์
 	sub := body.UnitPrice * float64(body.QTY)
-	total := sub - body.LineDiscount
-	if total < 0 {
-		total = 0
-	}
-	body.LineTotal = math.Round(total*100) / 100
+	discount := 0.0
 
-	if err := db.Create(&body).Error; err != nil {
+	now := time.Now()
+	var promos []entity.Promotion
+	// โปรโมชันจากเกม
+	if gameID != 0 {
+		var gamePromos []entity.Promotion
+		db.Joins("JOIN promotion_games pg ON pg.promotion_id = promotions.id").
+			Where("pg.game_id = ? AND promotions.status = 1 AND promotions.start_date <= ? AND promotions.end_date >= ?", gameID, now, now).
+			Find(&gamePromos)
+		promos = append(promos, gamePromos...)
+	}
+	// โปรโมชันจากออร์เดอร์
+	var orderPromos []entity.Promotion
+	db.Joins("JOIN order_promotions op ON op.promotion_id = promotions.id").
+		Where("op.order_id = ? AND promotions.status = 1 AND promotions.start_date <= ? AND promotions.end_date >= ?", body.OrderID, now, now).
+		Find(&orderPromos)
+	promos = append(promos, orderPromos...)
+
+	for _, p := range promos {
+		var d float64
+		if p.DiscountType == entity.DiscountPercent {
+			d = sub * float64(p.DiscountValue) / 100
+		} else if p.DiscountType == entity.DiscountAmount {
+			d = float64(p.DiscountValue) * float64(body.QTY)
+		}
+		if d > discount {
+			discount = d
+		}
+	}
+	if discount > sub {
+		discount = sub
+	}
+	// ตรวจสอบถ้ามีส่ง line_discount/line_total มาต้องตรงกับที่คำนวณ
+	if body.LineDiscount != nil && math.Round(*body.LineDiscount*100)/100 != math.Round(discount*100)/100 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "line_discount mismatch"})
+		return
+	}
+	total := sub - discount
+	total = math.Round(total*100) / 100
+	if body.LineTotal != nil && math.Round(*body.LineTotal*100)/100 != total {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "line_total mismatch"})
+		return
+	}
+
+	item := entity.OrderItem{
+		UnitPrice:    body.UnitPrice,
+		QTY:          body.QTY,
+		LineDiscount: math.Round(discount*100) / 100,
+		LineTotal:    total,
+		OrderID:      body.OrderID,
+		GameKeyID:    body.GameKeyID,
+	}
+
+	if err := db.Create(&item).Error; err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -59,10 +120,10 @@ func CreateOrderItem(c *gin.Context) {
 	if body.GameKeyID != nil {
 		db.Model(&entity.KeyGame{}).
 			Where("id = ?", *body.GameKeyID).
-			Update("order_item_id", body.ID)
+			Update("order_item_id", item.ID)
 	}
 
-	c.JSON(http.StatusCreated, body)
+	c.JSON(http.StatusCreated, item)
 }
 
 func FindOrderItems(c *gin.Context) {

--- a/backend/controllers/order_item_test.go
+++ b/backend/controllers/order_item_test.go
@@ -1,0 +1,99 @@
+package controllers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+	"github.com/gin-gonic/gin"
+)
+
+func TestCreateOrderItemWithPromotion(t *testing.T) {
+	os.Setenv("DB_PATH", "file::memory:?cache=shared")
+	configs.ConnectionDB()
+	db := configs.DB()
+	if err := db.AutoMigrate(&entity.User{}, &entity.Order{}, &entity.Game{}, &entity.KeyGame{}, &entity.OrderItem{}, &entity.Promotion{}, &entity.Promotion_Game{}, &entity.OrderPromotion{}); err != nil {
+		t.Fatalf("migrate failed: %v", err)
+	}
+
+	// create user and order
+	user := entity.User{Username: "tester"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	order := entity.Order{UserID: user.ID, OrderCreate: time.Now()}
+	if err := db.Create(&order).Error; err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+
+	// create category, game and key
+	cat := entity.Categories{Title: "Test"}
+	if err := db.Create(&cat).Error; err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+	// disable FK to insert game before key
+	db.Exec("PRAGMA foreign_keys = OFF")
+	game := entity.Game{GameName: "TestGame", BasePrice: 100, CategoriesID: int(cat.ID)}
+	if err := db.Create(&game).Error; err != nil {
+		t.Fatalf("create game: %v", err)
+	}
+	key := entity.KeyGame{GameID: game.ID}
+	if err := db.Create(&key).Error; err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+	if err := db.Model(&game).Update("key_game_id", key.ID).Error; err != nil {
+		t.Fatalf("update game key: %v", err)
+	}
+	db.Exec("PRAGMA foreign_keys = ON")
+
+	// create promotion for game
+	now := time.Now()
+	promo := entity.Promotion{
+		Title:         "Promo10",
+		DiscountType:  entity.DiscountPercent,
+		DiscountValue: 10,
+		StartDate:     now.Add(-time.Hour),
+		EndDate:       now.Add(time.Hour),
+		Status:        true,
+		UserID:        user.ID,
+	}
+	if err := db.Create(&promo).Error; err != nil {
+		t.Fatalf("create promo: %v", err)
+	}
+	if err := db.Create(&entity.Promotion_Game{PromotionID: promo.ID, GameID: game.ID}).Error; err != nil {
+		t.Fatalf("link promo: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	payload := map[string]interface{}{
+		"unit_price":  100,
+		"qty":         1,
+		"order_id":    order.ID,
+		"game_key_id": key.ID,
+	}
+	b, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/order-items", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	CreateOrderItem(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", w.Code)
+	}
+	var resp entity.OrderItem
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid response: %v", err)
+	}
+	if resp.LineDiscount != 10 || resp.LineTotal != 90 {
+		t.Fatalf("unexpected discount or total: %+v", resp)
+	}
+}

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -1,35 +1,39 @@
-import { Row, Col } from 'antd';
-import AddProductCard from './AddProductCard';
-import { Link, useNavigate } from 'react-router-dom';
-import { Card, Button } from 'antd';
-import { useState, useEffect } from 'react';
-import axios from 'axios';
+import { Row, Col } from "antd";
+import AddProductCard from "./AddProductCard";
+import { Link, useNavigate } from "react-router-dom";
+import { Card, Button } from "antd";
+import { useState, useEffect } from "react";
+import axios from "axios";
 
-const base_url = 'http://localhost:8088';
+const base_url = "http://localhost:8088";
 
 const ProductGrid = () => {
   interface Game {
-      ID: number;
-      game_name: string;
-      key_id: number;
-      categories: {ID: number, title: string};
-      release_date: string;
-      base_price: number;
-      /** Price after applying promotion. Undefined when no promotion */
-      discounted_price?: number;
-      img_src: string;
-      age_rating: number;
-      status: string;
-      minimum_spec_id: number;
+    ID: number;
+    game_name: string;
+    key_id: number;
+    categories: { ID: number; title: string };
+    release_date: string;
+    base_price: number;
+    /** Price after applying promotion. Undefined when no promotion */
+    discounted_price?: number;
+    img_src: string;
+    age_rating: number;
+    status: string;
+    minimum_spec_id: number;
   }
 
   // แปลง img_src ให้เป็น absolute URL เสมอ
   const resolveImgUrl = (src?: string) => {
     if (!src) return "";
     if (src.startsWith("blob:")) return "";
-    if (src.startsWith("data:image/")) return src; 
+    if (src.startsWith("data:image/")) return src;
     // ถ้าเป็น blob: เดิม จะมักใช้ไม่ได้ในหน้าอื่น — ควรแก้ฝั่ง backend ให้ส่ง URL ถาวร
-    if (src.startsWith("http://") || src.startsWith("https://") || src.startsWith("blob:")) {
+    if (
+      src.startsWith("http://") ||
+      src.startsWith("https://") ||
+      src.startsWith("blob:")
+    ) {
       return src;
     }
     // ถ้า backend ส่งเป็น "uploads/xxx.jpg" หรือ "/uploads/xxx.jpg"
@@ -46,7 +50,7 @@ const ProductGrid = () => {
       Setgame(response.data);
       console.log(response.data);
     } catch (err) {
-      console.log('get game error', err);
+      console.log("get game error", err);
     }
   }
   useEffect(() => {
@@ -59,61 +63,67 @@ const ProductGrid = () => {
       const res = await axios.post(`${base_url}/orders`, {
         user_id: 1,
         total_amount: price,
-        order_status: 'PENDING',
+        order_status: "PENDING",
         order_items: [
           {
             unit_price: price,
             qty: 1,
-            line_discount: 0,
-            line_total: price,
             game_key_id: g.key_id,
           },
         ],
       });
       const orderId = res.data.ID || res.data.id;
       if (orderId) {
-        localStorage.setItem('orderId', String(orderId));
+        localStorage.setItem("orderId", String(orderId));
       }
-      navigate('/category/Payment');
+      navigate("/category/Payment");
     } catch (err) {
-      console.error('add to cart error', err);
+      console.error("add to cart error", err);
     }
   };
 
   return (
-    <Row gutter={[16, 16]}> 
-      {game.map((c) => ( 
-        <Col xs={24} sm={12} md={8} lg={6} >
+    <Row gutter={[16, 16]}>
+      {game.map((c) => (
+        <Col xs={24} sm={12} md={8} lg={6}>
           <Card
-          style={{ background: '#1f1f1f', color: 'white', borderRadius: 10 }}
-          cover={ <img src={resolveImgUrl(c.img_src)} style={{height: 150}}/>}
-        >
-        <Card.Meta title={<div style={{color: '#ffffffff'}}>{c.game_name}</div>} description={<div style={{color: '#ffffffff'}}>{c.categories.title}</div>}/>
-          <div style={{ marginTop: 10, color: '#9254de' }}>
-            {c.discounted_price ? (
-              <>
-                <span style={{ textDecoration: 'line-through', color: '#ccc' }}>
-                  {c.base_price}
-                </span>
-                <span style={{ marginLeft: 8 }}>{c.discounted_price}</span>
-              </>
-            ) : (
-              c.base_price
-            )}
-          </div>
-          <Button
-            block
-            style={{ marginTop: 10 }}
-            onClick={() => handleAddToCart(c)}
+            style={{ background: "#1f1f1f", color: "white", borderRadius: 10 }}
+            cover={
+              <img src={resolveImgUrl(c.img_src)} style={{ height: 150 }} />
+            }
           >
-            Add to Cart
-          </Button>
+            <Card.Meta
+              title={<div style={{ color: "#ffffffff" }}>{c.game_name}</div>}
+              description={
+                <div style={{ color: "#ffffffff" }}>{c.categories.title}</div>
+              }
+            />
+            <div style={{ marginTop: 10, color: "#9254de" }}>
+              {c.discounted_price ? (
+                <>
+                  <span
+                    style={{ textDecoration: "line-through", color: "#ccc" }}
+                  >
+                    {c.base_price}
+                  </span>
+                  <span style={{ marginLeft: 8 }}>{c.discounted_price}</span>
+                </>
+              ) : (
+                c.base_price
+              )}
+            </div>
+            <Button
+              block
+              style={{ marginTop: 10 }}
+              onClick={() => handleAddToCart(c)}
+            >
+              Add to Cart
+            </Button>
           </Card>
         </Col>
-      ))
-      }
+      ))}
       <Col xs={24} sm={12} md={8} lg={6}>
-        <Link to={'/information/Add'}>
+        <Link to={"/information/Add"}>
           <AddProductCard />
         </Link>
       </Col>

--- a/frontend/src/interfaces/OrderItem.ts
+++ b/frontend/src/interfaces/OrderItem.ts
@@ -15,8 +15,6 @@ export interface OrderItem {
 export interface CreateOrderItemRequest {
   unit_price: number;
   qty: number;
-  line_discount: number;
-  line_total: number;
   order_id: number;
   game_key_id?: number | null;
 }
@@ -25,8 +23,6 @@ export interface UpdateOrderItemRequest {
   ID: number;
   unit_price?: number;
   qty?: number;
-  line_discount?: number;
-  line_total?: number;
   order_id?: number;
   game_key_id?: number | null;
 }


### PR DESCRIPTION
## Summary
- Calculate `line_discount` and `line_total` in `CreateOrderItem` using promotions attached to the game or order
- Prevent clients from submitting custom discounts and validate any supplied values
- Add test ensuring discounted total is derived from active promotions
- Remove discount fields from order item creation request on the frontend

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Multiple lint errors across frontend)*

------
https://chatgpt.com/codex/tasks/task_e_68bebf3c0cc4832980f753edfbeb6e2b