### PR TITLE
Use token-derived user ID when creating orders

### DIFF
--- a/backend/controllers/order.go
+++ b/backend/controllers/order.go
@@ -16,9 +16,19 @@ func CreateOrder(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
 		return
 	}
+
+	// ดึง user id จาก token
+	user, ok := c.Get("user_id")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	uid := user.(uint)
+	body.UserID = uid
+
 	// ตรวจ User
-	var user entity.User
-	if tx := configs.DB().First(&user, body.UserID); tx.RowsAffected == 0 {
+	var u entity.User
+	if tx := configs.DB().First(&u, uid); tx.RowsAffected == 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id not found"})
 		return
 	}

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -94,7 +94,6 @@ const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
         const orderRes = await axios.post(
           `${base_url}/orders`,
           {
-            user_id: userId,
             total_amount: 0,
             order_status: 'PENDING',
           },

--- a/frontend/src/interfaces/Order.ts
+++ b/frontend/src/interfaces/Order.ts
@@ -20,7 +20,6 @@ export interface Order {
 export interface CreateOrderRequest {
   total_amount: number;
   order_status: string;
-  user_id: number;
   order_create?: string; // ถ้าไม่ส่ง backend จะใส่ให้
 }
 


### PR DESCRIPTION
## Summary
- Derive the user ID for new orders from the authenticated Gin context instead of the request body
- Remove `user_id` from frontend order creation payload and interface

## Testing
- `go test ./...`
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bec74a3e58832291301aacb4d50195