### PR TITLE
refactor: remove fallback game listing

### DIFF
--- a/frontend/src/pages/Promotion/PromotionDetail.tsx
+++ b/frontend/src/pages/Promotion/PromotionDetail.tsx
@@ -4,7 +4,7 @@ import { Layout, Typography, Card, Tag, List, Button, Empty } from "antd";
 import Sidebar from "../../components/Sidebar";
 import type { Promotion } from "../../interfaces/Promotion";
 import type { Game } from "../../interfaces/Game";
-import { getPromotion, listGames } from "../../services/promotions";
+import { getPromotion } from "../../services/promotions";
 import dayjs from "dayjs";
 
 const { Content } = Layout;
@@ -19,13 +19,10 @@ export default function PromotionDetail() {
     const load = async () => {
       if (!id) return;
       try {
-        const data = await getPromotion(Number(id));
+        const data = await getPromotion(Number(id), true);
         setPromotion(data);
         if (data.games) {
           setGames(data.games);
-        } else {
-          const all = await listGames();
-          setGames(all);
         }
       } catch {
         setPromotion(null);


### PR DESCRIPTION
## Summary
- fetch promotion with games included
- drop fallback game listing logic

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, unused vars, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68bfbfde02fc8329ac214c6741ec84f5