### PR TITLE
Serve static uploads directory

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -16,6 +16,7 @@ func main() {
 	configs.SetupDatabase()
 
 	r := gin.Default()
+	r.Static("/uploads", "./uploads")
 	r.Use(CORSMiddleware())
 
 	// health check ง่าย ๆ


### PR DESCRIPTION
## Summary
- serve `./uploads` at `/uploads` with gin router

## Testing
- `go test ./...` *(fails: hung due to environment)*
- `go build` *(fails: hung due to environment)*


------
https://chatgpt.com/codex/tasks/task_e_68bfd2b3a01083298698cf708c82f010