### PR TITLE
feat: show promotion banner full width

### DIFF
--- a/frontend/src/pages/Promotion/PromotionDetail.tsx
+++ b/frontend/src/pages/Promotion/PromotionDetail.tsx
@@ -64,10 +64,22 @@ export default function PromotionDetail() {
     <Layout style={{ minHeight: "100vh", background: "#0f0f0f" }}>
       <Sidebar />
       <Content style={{ padding: 24, background: "#141414" }}>
+        {promotion.promo_image && (
+          <Image
+            src={resolveImgUrl(promotion.promo_image)}
+            alt={promotion.title}
+            preview={false}
+            style={{
+              width: "100%",
+              height: 220,
+              objectFit: "cover",
+              display: "block",
+              borderRadius: 0,
+              marginBottom: 16,
+            }}
+          />
+        )}
         <div style={{ maxWidth: 900, margin: "0 auto" }}>
-          {promotion.promo_image && (
-            <Image src={resolveImgUrl(promotion.promo_image)} alt={promotion.title} preview={false} style={{ width: '100%', height: 220, objectFit: 'cover', borderRadius: 10, marginBottom: 16 }} />
-          )}
 
           <Card style={{ background: "#1f1f1f", color: "white", borderRadius: 10, marginBottom: 16 }}>
             <Title level={3} style={{ color: "white", margin: 0 }}>


### PR DESCRIPTION
## Summary
- show promotion banner across full width and remove rounded corners

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars)*
- `npm run build` *(fails: type errors in unrelated files)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68bfdca16c2883299335353cc11f9efe