### PR TITLE
feat: add admin report view with user notifications

### DIFF
--- a/backend/configs/db.go
+++ b/backend/configs/db.go
@@ -63,6 +63,8 @@ func SetupDatabase() {
 		&entity.Categories{},
 		&entity.MinimumSpec{},
 		&entity.Request{},
+		&entity.ProblemReport{},
+		&entity.ProblemAttachment{},
 	); err != nil {
 		log.Fatal("auto migrate failed: ", err)
 	}

--- a/backend/controllers/problem_report.go
+++ b/backend/controllers/problem_report.go
@@ -91,7 +91,7 @@ func CreateReport(c *gin.Context) {
 		}
 	}
 
-	_ = db.Preload("Attachments").First(&report, report.ID).Error
+	_ = db.Preload("Attachments").Preload("User").Preload("Game").First(&report, report.ID).Error
 	c.JSON(http.StatusCreated, report)
 }
 
@@ -138,7 +138,7 @@ func FindReports(c *gin.Context) {
 	_ = q.Count(&total).Error
 
 	var items []entity.ProblemReport
-	if err := q.Preload("Attachments").
+	if err := q.Preload("Attachments").Preload("User").Preload("Game").
 		Order("created_at DESC").
 		Offset(offset).Limit(limit).
 		Find(&items).Error; err != nil {
@@ -160,7 +160,7 @@ func GetReportByID(c *gin.Context) {
 	id, _ := strconv.Atoi(c.Param("id"))
 
 	var rp entity.ProblemReport
-	if err := db.Preload("Attachments").First(&rp, id).Error; err != nil {
+	if err := db.Preload("Attachments").Preload("User").Preload("Game").First(&rp, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "report not found"})
 			return
@@ -226,7 +226,7 @@ func UpdateReport(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	_ = db.Preload("Attachments").First(&rp, rp.ID).Error
+	_ = db.Preload("Attachments").Preload("User").Preload("Game").First(&rp, rp.ID).Error
 	c.JSON(http.StatusOK, rp)
 }
 

--- a/backend/entity/problem_report.go
+++ b/backend/entity/problem_report.go
@@ -10,11 +10,15 @@ type ProblemReport struct {
 	gorm.Model
 	Title       string    `json:"title"`
 	Description string    `json:"description"`
-	Status      string    `json:"status"`       // e.g. "open", "resolved", "in_progress"
-	ResolvedAt  time.Time `json:"resolved_at"`  // zero-time = ยังไม่ปิดงาน
+	Status      string    `json:"status"`      // e.g. "open", "resolved", "in_progress"
+	ResolvedAt  time.Time `json:"resolved_at"` // zero-time = ยังไม่ปิดงาน
 
 	UserID uint `json:"user_id"`
 	GameID uint `json:"game_id"`
+
+	// Preloadable relations
+	User *User `gorm:"foreignKey:UserID" json:"user"`
+	Game *Game `gorm:"foreignKey:GameID" json:"game"`
 
 	Attachments []ProblemAttachment `gorm:"foreignKey:ReportID" json:"attachments"`
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -109,6 +109,13 @@ func main() {
 		router.POST("/new-minimumspec", controllers.CreateMinimumSpec)
 		router.GET("/minimumspec", controllers.FindMinimumSpec)
 
+		// ===== Problem Reports =====
+		router.POST("/reports", controllers.CreateReport)
+		router.GET("/reports", controllers.FindReports)
+		router.GET("/reports/:id", controllers.GetReportByID)
+		router.PUT("/reports/:id", controllers.UpdateReport)
+		router.DELETE("/reports/:id", controllers.DeleteReport)
+
 		//request routes
 		router.POST("/new-request", controllers.CreateRequest)
 		router.GET("/request", controllers.FindRequest)

--- a/frontend/src/interfaces/problem_report.ts
+++ b/frontend/src/interfaces/problem_report.ts
@@ -1,4 +1,6 @@
 import type { ProblemAttachment } from "./problem_attachment";
+import type { User } from "./User";
+import type { Game } from "./Game";
 
 export interface ProblemReport {
   ID: number;
@@ -10,6 +12,9 @@ export interface ProblemReport {
 
   UserID: number;
   GameID: number;
+
+  User?: User;
+  Game?: Game;
 
   Attachments?: ProblemAttachment[]; // optional เพื่อให้โหลดเฉพาะตอนต้องการ
 }

--- a/frontend/src/services/Notification.ts
+++ b/frontend/src/services/Notification.ts
@@ -1,0 +1,12 @@
+import api from "../lib/api";
+import type { Notification, CreateNotificationRequest } from "../interfaces/Notification";
+
+export async function fetchNotifications(userId: number): Promise<Notification[]> {
+  const { data } = await api.get("/notifications", { params: { user_id: userId } });
+  return data as Notification[];
+}
+
+export async function createNotification(payload: CreateNotificationRequest): Promise<Notification> {
+  const { data } = await api.post("/notifications", payload);
+  return data as Notification;
+}

--- a/frontend/src/services/Report.ts
+++ b/frontend/src/services/Report.ts
@@ -1,4 +1,5 @@
 import api from "../lib/api";
+import type { ProblemReport } from "../interfaces/problem_report";
 
 export type CreateReportInput = {
   title: string;
@@ -25,4 +26,14 @@ export async function createReport(input: CreateReportInput) {
     headers: { "Content-Type": "multipart/form-data" },
   });
   return data;
+}
+
+export async function fetchReports(): Promise<ProblemReport[]> {
+  const { data } = await api.get("/reports");
+  return (data.items ?? data) as ProblemReport[];
+}
+
+export async function resolveReport(id: number) {
+  const { data } = await api.put(`/reports/${id}`, { resolve: true });
+  return data as ProblemReport;
 }


### PR DESCRIPTION
## Summary
- migrate problem reports and attachments
- add report routes and user/game relations
- fetch reports on admin page and allow replies to notify users
- poll notifications for logged-in users

## Testing
- `go build ./...`
- `npm run lint` *(fails: Unexpected any and unused vars in existing files)*
- `npx eslint src/components/Navbar.tsx src/pages/Admin/AdminPage.tsx src/interfaces/problem_report.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bff63521d48323bc022909d5bdbf76