### PR TITLE
feat: integrate community threads with backend

### DIFF
--- a/frontend/src/pages/Community/CommunityPage.tsx
+++ b/frontend/src/pages/Community/CommunityPage.tsx
@@ -1,91 +1,88 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { message, Space, Select } from "antd";
 import axios from "axios";
 import ThreadList from "./ThreadList";
 import ThreadDetail from "./ThreadDetail";
 import type { Thread, ThreadComment } from "./types";
+import { useAuth } from "../../context/AuthContext";
 
 const base_url = "http://localhost:8088";
 
 export default function CommunityPage() {
-  // --- mock data เริ่มต้น ---
-  const [threads, setThreads] = useState<Thread[]>([
-    {
-      id: 1,
-      title: "How high can we count before EA does something…?",
-      body: "Rules: Just be respectful.",
-      author: "neurougue",
-      createdAt: "3 ชม.ที่แล้ว",
-      likes: 2,
-      commentCount: 2,
-      comments: [
-        { id: 11, author: "Yanis_zaky", content: "1", datetime: "3 ชม. @ 8:17am" },
-        { id: 12, author: "MaT", content: "2", datetime: "3 ชม. @ 5:06pm" },
-      ],
-    },
-    {
-      id: 2,
-      title: "For 1001st time MM is a joke",
-      body: "…",
-      author: "Sil Halcorrn",
-      createdAt: "8 ชม.ที่แล้ว",
-      likes: 1,
-      commentCount: 0,
-      comments: [],
-    },
-  ]);
-  // --------------------------
+  const { id: userId } = useAuth();
 
-  const idRef = useRef(1000);
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const [games, setGames] = useState<{ id: number; name: string }[]>([]);
+  const [selectedGameId, setSelectedGameId] = useState<number | null>(null);
   const [activeId, setActiveId] = useState<number | null>(null);
-  const [sortBy, setSortBy] = useState<'latest' | 'likes' | 'comments'>(
-    'latest'
-  );
+  const [sortBy, setSortBy] = useState<'latest' | 'likes' | 'comments'>('latest');
 
   const activeThread = useMemo(
     () => threads.find((t) => t.id === activeId) || null,
     [threads, activeId]
   );
 
-  // สร้างเธรดใหม่ (หน้า List เท่านั้น)
-  const createThread = ({ title, body, images }: { title: string; body: string; images?: string[] }) => {
-    const n: Thread = {
-      id: idRef.current++,
-      title,
-      body,
-      author: "คุณ",
-      createdAt: "เพิ่งโพสต์",
-      likes: 0,
-      commentCount: 0,
-      comments: [],
-      images, // ✅ เก็บรูปไปกับเธรด
-    };
-    setThreads((prev) => [n, ...prev]);
-    message.success("สร้างเธรดใหม่แล้ว");
+  const buildCommentTree = (items: any[]): ThreadComment[] => {
+    const map = new Map<number, ThreadComment & { parentId?: number }>();
+    const roots: ThreadComment[] = [];
+    items.forEach((c: any) => {
+      map.set(c.ID, {
+        id: c.ID,
+        author: c.user?.username || "",
+        content: c.content,
+        datetime: c.CreatedAt || "",
+        children: [],
+        parentId: c.parent_comment_id,
+      });
+    });
+    map.forEach((item) => {
+      if (item.parentId) {
+        const parent = map.get(item.parentId);
+        if (parent) {
+          parent.children = parent.children || [];
+          parent.children.push(item);
+        } else {
+          roots.push(item);
+        }
+      } else {
+        roots.push(item);
+      }
+      delete (item as any).parentId;
+    });
+    return roots;
   };
 
-  // เพิ่มคอมเมนต์ที่ระดับ root ของเธรดที่เปิดอยู่ (หน้า Detail เท่านั้น)
-  const replyRoot = ({ content }: { content: string }) => {
-    if (!activeThread) return;
-    const newC: ThreadComment = {
-      id: idRef.current++,
-      author: "คุณ",
-      content,
-      datetime: "เพิ่งตอบกลับ",
-    };
-    setThreads((prev) =>
-      prev.map((t) =>
-        t.id === activeThread.id
-          ? { ...t, comments: [...t.comments, newC], commentCount: t.commentCount + 1 }
-          : t
-      )
+  const countComments = (arr: ThreadComment[]): number =>
+    arr.reduce(
+      (sum, c) => sum + 1 + (c.children ? countComments(c.children) : 0),
+      0
     );
-    message.success("ตอบกลับแล้ว");
+
+  const fetchComments = (threadId: number) => {
+    axios
+      .get(`${base_url}/comments`, { params: { thread_id: threadId } })
+      .then((res) => {
+        const tree = buildCommentTree(res.data);
+        setThreads((prev) =>
+          prev.map((t) =>
+            t.id === threadId
+              ? { ...t, comments: tree, commentCount: countComments(tree) }
+              : t
+          )
+        );
+      })
+      .catch(() => {});
   };
 
-  useEffect(() => {
+  const fetchThreads = () => {
+    if (!selectedGameId) {
+      setThreads([]);
+      return;
+    }
     axios
-      .get(`${base_url}/threads`, { params: { sort: sortBy } })
+      .get(`${base_url}/threads`, {
+        params: { game_id: selectedGameId, sort: sortBy },
+      })
       .then((res) => {
         const data = res.data.map((t: any) => ({
           id: t.ID,
@@ -100,7 +97,61 @@ export default function CommunityPage() {
         setThreads(data);
       })
       .catch(() => {});
-  }, [sortBy]);
+  };
+
+  const createThread = async ({ title, body }: { title: string; body: string; images?: string[] }) => {
+    if (!userId || !selectedGameId) {
+      message.error("กรุณาเลือกเกมก่อนโพสต์");
+      return;
+    }
+    try {
+      await axios.post(`${base_url}/threads`, {
+        title,
+        content: body,
+        user_id: userId,
+        game_id: selectedGameId,
+      });
+      message.success("สร้างเธรดใหม่แล้ว");
+      fetchThreads();
+    } catch {
+      message.error("สร้างเธรดล้มเหลว");
+    }
+  };
+
+  const replyRoot = async ({ content }: { content: string }) => {
+    if (!activeThread || !userId) return;
+    try {
+      await axios.post(`${base_url}/comments`, {
+        thread_id: activeThread.id,
+        user_id: userId,
+        content,
+      });
+      message.success("ตอบกลับแล้ว");
+      fetchComments(activeThread.id);
+    } catch {
+      message.error("ตอบกลับล้มเหลว");
+    }
+  };
+
+  useEffect(() => {
+    axios
+      .get(`${base_url}/game`)
+      .then((res) => {
+        const gs = res.data
+          .filter((g: any) => g.status === "approve")
+          .map((g: any) => ({ id: g.ID, name: g.game_name }));
+        setGames(gs);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    fetchThreads();
+  }, [selectedGameId, sortBy]);
+
+  useEffect(() => {
+    if (activeId != null) fetchComments(activeId);
+  }, [activeId]);
 
   return (
     <div style={{minHeight:'100vh', padding: 24 , flex: 1 , background: "#1e1e2f"}}>
@@ -113,16 +164,25 @@ export default function CommunityPage() {
         />
       ) : (
         <>
-          <Select
-            value={sortBy}
-            onChange={(v) => setSortBy(v)}
-            style={{ width: 200 }}
-            options={[
-              { value: 'latest', label: 'Latest' },
-              { value: 'likes', label: 'Likes' },
-              { value: 'comments', label: 'Comments' }
-            ]}
-          />
+          <Space>
+            <Select
+              placeholder="เลือกเกม"
+              value={selectedGameId ?? undefined}
+              onChange={(v) => setSelectedGameId(v)}
+              style={{ width: 200 }}
+              options={games.map((g) => ({ value: g.id, label: g.name }))}
+            />
+            <Select
+              value={sortBy}
+              onChange={(v) => setSortBy(v)}
+              style={{ width: 200 }}
+              options={[
+                { value: 'latest', label: 'Latest' },
+                { value: 'likes', label: 'Likes' },
+                { value: 'comments', label: 'Comments' }
+              ]}
+            />
+          </Space>
           <ThreadList
             threads={threads}
             sortBy={sortBy}


### PR DESCRIPTION
## Summary
- integrate community page with backend API
- load threads by game and sort order
- allow posting threads and comments via server

## Testing
- `npm --prefix frontend run lint` (fails: Unexpected any & other lint errors)
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68bffca0b47c8322ae877f39c634cb93