### PR TITLE
Integrate community threads with backend APIs

### DIFF
--- a/frontend/src/pages/Community/CommunityPage.tsx
+++ b/frontend/src/pages/Community/CommunityPage.tsx
@@ -1,42 +1,36 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { message, Space, Select } from "antd";
 import axios from "axios";
 import ThreadList from "./ThreadList";
 import ThreadDetail from "./ThreadDetail";
 import type { Thread, ThreadComment } from "./types";
+import { useAuth } from "../../context/AuthContext";
 
 const base_url = "http://localhost:8088";
 
 export default function CommunityPage() {
-  // --- mock data เริ่มต้น ---
-  const [threads, setThreads] = useState<Thread[]>([
-    {
-      id: 1,
-      title: "How high can we count before EA does something…?",
-      body: "Rules: Just be respectful.",
-      author: "neurougue",
-      createdAt: "3 ชม.ที่แล้ว",
-      likes: 2,
-      commentCount: 2,
-      comments: [
-        { id: 11, author: "Yanis_zaky", content: "1", datetime: "3 ชม. @ 8:17am" },
-        { id: 12, author: "MaT", content: "2", datetime: "3 ชม. @ 5:06pm" },
-      ],
-    },
-    {
-      id: 2,
-      title: "For 1001st time MM is a joke",
-      body: "…",
-      author: "Sil Halcorrn",
-      createdAt: "8 ชม.ที่แล้ว",
-      likes: 1,
-      commentCount: 0,
-      comments: [],
-    },
-  ]);
-  // --------------------------
+  const { id: user_id } = useAuth();
 
-  const idRef = useRef(1000);
+  const [threads, setThreads] = useState<Thread[]>([]);
+  type Game = { ID: number; game_name: string; status: string };
+  type ServerThread = {
+    ID: number;
+    title: string;
+    content: string;
+    user?: { username?: string };
+    CreatedAt?: string;
+    likes: number;
+    comments: number;
+  };
+  type ServerComment = {
+    ID: number;
+    content: string;
+    user?: { username?: string };
+    CreatedAt?: string;
+    parent_comment_id?: number | null;
+  };
+  const [games, setGames] = useState<Game[]>([]);
+  const [selectedGameId, setSelectedGameId] = useState<number | null>(null);
   const [activeId, setActiveId] = useState<number | null>(null);
   const [sortBy, setSortBy] = useState<'latest' | 'likes' | 'comments'>(
     'latest'
@@ -47,91 +41,139 @@ export default function CommunityPage() {
     [threads, activeId]
   );
 
-  // สร้างเธรดใหม่ (หน้า List เท่านั้น)
-  const createThread = ({ title, body, images }: { title: string; body: string; images?: string[] }) => {
-    const n: Thread = {
-      id: idRef.current++,
-      title,
-      body,
-      author: "คุณ",
-      createdAt: "เพิ่งโพสต์",
-      likes: 0,
-      commentCount: 0,
-      comments: [],
-      images, // ✅ เก็บรูปไปกับเธรด
-    };
-    setThreads((prev) => [n, ...prev]);
-    message.success("สร้างเธรดใหม่แล้ว");
-  };
-
-  // เพิ่มคอมเมนต์ที่ระดับ root ของเธรดที่เปิดอยู่ (หน้า Detail เท่านั้น)
-  const replyRoot = ({ content }: { content: string }) => {
-    if (!activeThread) return;
-    const newC: ThreadComment = {
-      id: idRef.current++,
-      author: "คุณ",
-      content,
-      datetime: "เพิ่งตอบกลับ",
-    };
-    setThreads((prev) =>
-      prev.map((t) =>
-        t.id === activeThread.id
-          ? { ...t, comments: [...t.comments, newC], commentCount: t.commentCount + 1 }
-          : t
-      )
-    );
-    message.success("ตอบกลับแล้ว");
-  };
-
   useEffect(() => {
+    axios.get(`${base_url}/game`).then((res) => {
+      const approved = (res.data as Game[]).filter((g) => g.status === 'approve');
+      setGames(approved);
+      if (approved.length) {
+        setSelectedGameId(approved[0].ID);
+      }
+    });
+  }, []);
+
+  const fetchThreads = useCallback(() => {
+    if (!selectedGameId) return;
     axios
-      .get(`${base_url}/threads`, { params: { sort: sortBy } })
+      .get(`${base_url}/threads`, { params: { sort: sortBy, game_id: selectedGameId } })
       .then((res) => {
-        const data = res.data.map((t: any) => ({
+        const data = (res.data as ServerThread[]).map((t) => ({
           id: t.ID,
           title: t.title,
           body: t.content,
-          author: t.user?.username || "",
-          createdAt: t.CreatedAt || "",
+          author: t.user?.username || '',
+          createdAt: t.CreatedAt || '',
           likes: t.likes,
           commentCount: t.comments,
           comments: [],
-        })) as Thread[];
+        }));
         setThreads(data);
       })
       .catch(() => {});
-  }, [sortBy]);
+  }, [selectedGameId, sortBy]);
+
+  useEffect(() => {
+    fetchThreads();
+  }, [fetchThreads]);
+
+  const createThread = ({ title, body }: { title: string; body: string; images?: string[] }) => {
+    if (!user_id || !selectedGameId) {
+      message.error('กรุณาเลือกเกมและเข้าสู่ระบบ');
+      return;
+    }
+    axios
+      .post(`${base_url}/threads`, {
+        title,
+        content: body,
+        user_id,
+        game_id: selectedGameId,
+      })
+      .then(() => {
+        message.success('สร้างเธรดใหม่แล้ว');
+        fetchThreads();
+      })
+      .catch(() => message.error('ไม่สามารถสร้างเธรดได้'));
+  };
+
+  const fetchComments = useCallback((threadId: number) => {
+    axios
+      .get(`${base_url}/comments`, { params: { thread_id: threadId } })
+      .then((res) => {
+        const data: ThreadComment[] = (res.data as ServerComment[])
+          .filter((c) => c.parent_comment_id == null)
+          .map((c) => ({
+            id: c.ID,
+            author: c.user?.username || '',
+            content: c.content,
+            datetime: c.CreatedAt || '',
+          }));
+        setThreads((prev) =>
+          prev.map((t) =>
+            t.id === threadId
+              ? { ...t, comments: data, commentCount: data.length }
+              : t
+          )
+        );
+      });
+  }, []);
+
+  const openThread = (id: number) => {
+    setActiveId(id);
+    fetchComments(id);
+  };
+
+  const replyRoot = ({ content }: { content: string }) => {
+    if (!activeThread || !user_id) return;
+    axios
+      .post(`${base_url}/comments`, {
+        thread_id: activeThread.id,
+        user_id,
+        content,
+      })
+      .then(() => {
+        fetchComments(activeThread.id);
+        message.success('ตอบกลับแล้ว');
+      })
+      .catch(() => message.error('ไม่สามารถตอบกลับได้'));
+  };
 
   return (
-    <div style={{minHeight:'100vh', padding: 24 , flex: 1 , background: "#1e1e2f"}}>
-    <Space direction="vertical" size="large" style={{ width: "100%" }}>
-      {activeThread ? (
-        <ThreadDetail
-          thread={activeThread}
-          onBack={() => setActiveId(null)}
-          onReplyRoot={replyRoot}
-        />
-      ) : (
-        <>
-          <Select
-            value={sortBy}
-            onChange={(v) => setSortBy(v)}
-            style={{ width: 200 }}
-            options={[
-              { value: 'latest', label: 'Latest' },
-              { value: 'likes', label: 'Likes' },
-              { value: 'comments', label: 'Comments' }
-            ]}
+    <div style={{ minHeight: '100vh', padding: 24, flex: 1, background: '#1e1e2f' }}>
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        {activeThread ? (
+          <ThreadDetail
+            thread={activeThread}
+            onBack={() => setActiveId(null)}
+            onReplyRoot={replyRoot}
           />
-          <ThreadList
-            threads={threads}
-            sortBy={sortBy}
-            onOpen={(id) => setActiveId(id)}
-            onCreate={createThread}
-          />
-        </>
-      )}
-    </Space>
+        ) : (
+          <>
+            <Space>
+                <Select
+                  value={selectedGameId ?? undefined}
+                  onChange={(v) => setSelectedGameId(v)}
+                  style={{ width: 200 }}
+                  options={games.map((g) => ({ value: g.ID, label: g.game_name }))}
+                />
+              <Select
+                value={sortBy}
+                onChange={(v) => setSortBy(v)}
+                style={{ width: 200 }}
+                options={[
+                  { value: 'latest', label: 'Latest' },
+                  { value: 'likes', label: 'Likes' },
+                  { value: 'comments', label: 'Comments' },
+                ]}
+              />
+            </Space>
+            <ThreadList
+              threads={threads}
+              sortBy={sortBy}
+              onOpen={openThread}
+              onCreate={createThread}
+            />
+          </>
+        )}
+      </Space>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Load approved games and server threads, replacing mock community data
- Allow creating threads and posting comments via backend endpoints
- Refresh thread and comment lists when selections change

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 38 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bffe6117ec8322882d64abfa10e561