### PR TITLE
feat: add admin report view with user notifications

### DIFF
--- a/backend/configs/db.go
+++ b/backend/configs/db.go
@@ -63,6 +63,8 @@ func SetupDatabase() {
 		&entity.Categories{},
 		&entity.MinimumSpec{},
 		&entity.Request{},
+		&entity.ProblemReport{},
+		&entity.ProblemAttachment{},
 	); err != nil {
 		log.Fatal("auto migrate failed: ", err)
 	}

--- a/backend/controllers/problem_report.go
+++ b/backend/controllers/problem_report.go
@@ -91,7 +91,7 @@ func CreateReport(c *gin.Context) {
 		}
 	}
 
-	_ = db.Preload("Attachments").First(&report, report.ID).Error
+	_ = db.Preload("Attachments").Preload("User").Preload("Game").First(&report, report.ID).Error
 	c.JSON(http.StatusCreated, report)
 }
 
@@ -138,7 +138,7 @@ func FindReports(c *gin.Context) {
 	_ = q.Count(&total).Error
 
 	var items []entity.ProblemReport
-	if err := q.Preload("Attachments").
+	if err := q.Preload("Attachments").Preload("User").Preload("Game").
 		Order("created_at DESC").
 		Offset(offset).Limit(limit).
 		Find(&items).Error; err != nil {
@@ -160,7 +160,7 @@ func GetReportByID(c *gin.Context) {
 	id, _ := strconv.Atoi(c.Param("id"))
 
 	var rp entity.ProblemReport
-	if err := db.Preload("Attachments").First(&rp, id).Error; err != nil {
+	if err := db.Preload("Attachments").Preload("User").Preload("Game").First(&rp, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "report not found"})
 			return
@@ -226,7 +226,7 @@ func UpdateReport(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	_ = db.Preload("Attachments").First(&rp, rp.ID).Error
+	_ = db.Preload("Attachments").Preload("User").Preload("Game").First(&rp, rp.ID).Error
 	c.JSON(http.StatusOK, rp)
 }
 

--- a/backend/entity/problem_report.go
+++ b/backend/entity/problem_report.go
@@ -10,11 +10,15 @@ type ProblemReport struct {
 	gorm.Model
 	Title       string    `json:"title"`
 	Description string    `json:"description"`
-	Status      string    `json:"status"`       // e.g. "open", "resolved", "in_progress"
-	ResolvedAt  time.Time `json:"resolved_at"`  // zero-time = ยังไม่ปิดงาน
+	Status      string    `json:"status"`      // e.g. "open", "resolved", "in_progress"
+	ResolvedAt  time.Time `json:"resolved_at"` // zero-time = ยังไม่ปิดงาน
 
 	UserID uint `json:"user_id"`
 	GameID uint `json:"game_id"`
+
+	// Preloadable relations
+	User *User `gorm:"foreignKey:UserID" json:"user"`
+	Game *Game `gorm:"foreignKey:GameID" json:"game"`
 
 	Attachments []ProblemAttachment `gorm:"foreignKey:ReportID" json:"attachments"`
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -109,6 +109,13 @@ func main() {
 		router.POST("/new-minimumspec", controllers.CreateMinimumSpec)
 		router.GET("/minimumspec", controllers.FindMinimumSpec)
 
+		// ===== Problem Reports =====
+		router.POST("/reports", controllers.CreateReport)
+		router.GET("/reports", controllers.FindReports)
+		router.GET("/reports/:id", controllers.GetReportByID)
+		router.PUT("/reports/:id", controllers.UpdateReport)
+		router.DELETE("/reports/:id", controllers.DeleteReport)
+
 		//request routes
 		router.POST("/new-request", controllers.CreateRequest)
 		router.GET("/request", controllers.FindRequest)

--- a/frontend/src/interfaces/problem_report.ts
+++ b/frontend/src/interfaces/problem_report.ts
@@ -1,40 +1,18 @@
 import type { ProblemAttachment } from "./problem_attachment";
+import type { User } from "./User";
+import type { Game } from "./Game";
 
 export interface ProblemReport {
   ID: number;
-  Title: string;
-  Description: string;
-  CreatedAt?: string;    // ใช้ ? เพราะอาจยังไม่ได้เซ็ต
-  ResolvedAt?: string;   // ใช้ ? เพราะอาจยังไม่ได้แก้ปัญหา
-  Status: string;
-
-  UserID: number;
-  GameID: number;
-
-  Attachments?: ProblemAttachment[]; // optional เพื่อให้โหลดเฉพาะตอนต้องการ
+  title: string;
+  description: string;
+  status: string;
+  created_at?: string;
+  resolved_at?: string;
+  user_id: number;
+  game_id: number;
+  user?: User;
+  game?: Game;
+  attachments?: ProblemAttachment[];
 }
 
-// สำหรับสร้างใหม่ผ่าน API
-export interface CreateProblemReportRequest {
-  Title: string;
-  Description: string;
-  CreatedAt?: string;
-  Status: string;
-  UserID: number;
-  GameID: number;
-}
-
-// สำหรับ backward compatibility หรือการใช้งานเก่า
-export interface ProblemReportInterface {
-  ID: number;
-  Title: string;
-  Description: string;
-  CreatedAt?: string;
-  ResolvedAt?: string;
-  Status: string;
-
-  UserID: number;
-  GameID: number;
-
-  Attachments?: ProblemAttachment[];
-}

--- a/frontend/src/pages/Admin/AdminPage.tsx
+++ b/frontend/src/pages/Admin/AdminPage.tsx
@@ -2,6 +2,10 @@
 import { useState, useEffect } from "react";
 import { Card, Button, Typography, Tag, Input, Upload, message, Modal } from "antd";
 import { UploadOutlined } from "@ant-design/icons";
+import { fetchReports, resolveReport } from "../../services/Report";
+import { createNotification } from "../../services/Notification";
+import type { ProblemReport } from "../../interfaces/problem_report";
+import type { UploadFile } from "antd/es/upload/interface";
 
 const { Title } = Typography;
 const { TextArea } = Input;
@@ -13,15 +17,6 @@ interface RefundRequest {
   game: string;
   reason: string;
   status: "Pending" | "Approved" | "Rejected";
-}
-
-interface ProblemReport {
-  id: number;
-  user: string;
-  category: string;
-  title: string;
-  description: string;
-  resolved: boolean;
 }
 
 interface AdminPageProps {
@@ -39,29 +34,22 @@ export default function AdminPage({
 }: AdminPageProps) {
   const [problems, setProblems] = useState<ProblemReport[]>([]);
   const [activeTab, setActiveTab] = useState<"refunds" | "problems">("refunds");
-  const [replies, setReplies] = useState<Record<number, { text: string; fileList: any[] }>>({});
+  const [replies, setReplies] = useState<Record<number, { text: string; fileList: UploadFile[] }>>({});
   const [previewImage, setPreviewImage] = useState<string>("");
   const [previewOpen, setPreviewOpen] = useState(false);
 
   useEffect(() => {
-    setProblems([
-      {
-        id: 1,
-        user: "Charlie",
-        category: "Login Issue",
-        title: "Can't login",
-        description: "Tried multiple times but login fails.",
-        resolved: false,
-      },
-      {
-        id: 2,
-        user: "Diana",
-        category: "Payment",
-        title: "Card declined",
-        description: "Even though balance is enough.",
-        resolved: true,
-      },
-    ]);
+    const load = async () => {
+      try {
+        const data = await fetchReports();
+        setProblems(data);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    load();
+    const timer = setInterval(load, 10000);
+    return () => clearInterval(timer);
   }, []);
 
   const handleRefundAction = (id: number, action: "Approved" | "Rejected") => {
@@ -73,27 +61,46 @@ export default function AdminPage({
     addRefundUpdate(`Refund #${id} ${action.toLowerCase()}`);
   };
 
-  const handleSendReply = (id: number) => {
-    const reply = replies[id];
+  const handleSendReply = async (rep: ProblemReport) => {
+    const reply = replies[rep.ID];
     if (!reply || (!reply.text && reply.fileList.length === 0)) {
       message.warning("กรุณาพิมพ์ข้อความหรือติดไฟล์อย่างน้อย 1 อย่าง");
       return;
     }
-    message.success("ส่งคำตอบกลับไปยังลูกค้าเรียบร้อย!");
-    addNotification(`Problem report #${id} has a reply`);
-    setReplies((prev) => ({ ...prev, [id]: { text: "", fileList: [] } }));
+    try {
+      await createNotification({
+        title: `ตอบกลับคำร้อง #${rep.ID}`,
+        message: reply.text,
+        type: "report",
+        user_id: rep.user_id,
+      });
+      message.success("ส่งคำตอบกลับไปยังลูกค้าเรียบร้อย!");
+      await resolveReport(rep.ID);
+      setProblems((prev) =>
+        prev.map((p) => (p.ID === rep.ID ? { ...p, status: "resolved" } : p))
+      );
+      addNotification(`Problem report #${rep.ID} has a reply`);
+    } catch (e) {
+      console.error(e);
+      message.error("ส่งคำตอบไม่สำเร็จ");
+    }
+    setReplies((prev) => ({ ...prev, [rep.ID]: { text: "", fileList: [] } }));
   };
 
-  const handleResolveProblem = (id: number) => {
-    setProblems((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, resolved: true } : p))
-    );
-    message.success(`Problem report #${id} marked as resolved`);
+  const handleResolveProblem = async (id: number) => {
+    try {
+      const updated = await resolveReport(id);
+      setProblems((prev) => prev.map((p) => (p.ID === id ? updated : p)));
+      message.success(`Problem report #${id} marked as resolved`);
+    } catch (e) {
+      console.error(e);
+      message.error("ไม่สามารถอัปเดตสถานะได้");
+    }
   };
 
-  const handlePreview = (file: any) => {
-    setPreviewImage(file.thumbUrl || file.url || "");
-    setPreviewOpen(true);
+  const handlePreview = (file: UploadFile) => {
+      setPreviewImage(file.thumbUrl || file.url || "");
+      setPreviewOpen(true);
   };
 
   const cardStyle = {
@@ -263,32 +270,31 @@ export default function AdminPage({
           }}
         >
           {problems.map((rep) => (
-            <Card key={rep.id} style={cardStyle}>
-              <p style={textStyle}>User: {rep.user}</p>
-              <p style={textStyle}>Category: {rep.category}</p>
+            <Card key={rep.ID} style={cardStyle}>
+              <p style={textStyle}>User: {rep.user?.username ?? rep.user_id}</p>
               <p style={textStyle}>Title: {rep.title}</p>
               <p style={textStyle}>Description: {rep.description}</p>
               <p style={textStyle}>
                 Status:{" "}
-                {rep.resolved ? (
+                {rep.status === "resolved" ? (
                   <Tag color="#52c41a">✅ Resolved</Tag>
                 ) : (
                   <Tag color="#f0a6ff">⏳ Pending</Tag>
                 )}
               </p>
 
-              {!rep.resolved && (
+              {rep.status !== "resolved" && (
                 <div style={{ marginTop: "20px" }}>
                   <TextArea
                     rows={3}
                     placeholder="พิมพ์ข้อความตอบกลับลูกค้า..."
-                    value={replies[rep.id]?.text || ""}
+                    value={replies[rep.ID]?.text || ""}
                     onChange={(e) =>
                       setReplies((prev) => ({
                         ...prev,
-                        [rep.id]: {
+                        [rep.ID]: {
                           text: e.target.value,
-                          fileList: prev[rep.id]?.fileList || [],
+                          fileList: prev[rep.ID]?.fileList || [],
                         },
                       }))
                     }
@@ -303,13 +309,13 @@ export default function AdminPage({
                     }}
                   />
                   <Upload
-                    fileList={replies[rep.id]?.fileList || []}
+                    fileList={replies[rep.ID]?.fileList || []}
                     beforeUpload={() => false}
-                    onChange={({ fileList }) =>
+                    onChange={({ fileList }: { fileList: UploadFile[] }) =>
                       setReplies((prev) => ({
                         ...prev,
-                        [rep.id]: {
-                          text: prev[rep.id]?.text || "",
+                        [rep.ID]: {
+                          text: prev[rep.ID]?.text || "",
                           fileList,
                         },
                       }))
@@ -318,8 +324,8 @@ export default function AdminPage({
                     listType="picture-card"
                     multiple
                   >
-                    {(!replies[rep.id] ||
-                      replies[rep.id].fileList.length < 5) && (
+                    {(!replies[rep.ID] ||
+                      replies[rep.ID].fileList.length < 5) && (
                       <div style={{ color: "#aaa" }}>
                         <UploadOutlined /> อัปโหลด
                       </div>
@@ -329,7 +335,7 @@ export default function AdminPage({
                     style={{ display: "flex", gap: "15px", marginTop: 12 }}
                   >
                     <Button
-                      onClick={() => handleSendReply(rep.id)}
+                      onClick={() => handleSendReply(rep)}
                       style={{
                         flex: 1,
                         background:
@@ -343,7 +349,7 @@ export default function AdminPage({
                       📩 Send Reply
                     </Button>
                     <Button
-                      onClick={() => handleResolveProblem(rep.id)}
+                      onClick={() => handleResolveProblem(rep.ID)}
                       style={{
                         flex: 1,
                         background:

--- a/frontend/src/services/Notification.ts
+++ b/frontend/src/services/Notification.ts
@@ -1,0 +1,12 @@
+import api from "../lib/api";
+import type { Notification, CreateNotificationRequest } from "../interfaces/Notification";
+
+export async function fetchNotifications(userId: number): Promise<Notification[]> {
+  const { data } = await api.get("/notifications", { params: { user_id: userId } });
+  return data as Notification[];
+}
+
+export async function createNotification(payload: CreateNotificationRequest): Promise<Notification> {
+  const { data } = await api.post("/notifications", payload);
+  return data as Notification;
+}

--- a/frontend/src/services/Report.ts
+++ b/frontend/src/services/Report.ts
@@ -1,4 +1,5 @@
 import api from "../lib/api";
+import type { ProblemReport } from "../interfaces/problem_report";
 
 export type CreateReportInput = {
   title: string;
@@ -25,4 +26,14 @@ export async function createReport(input: CreateReportInput) {
     headers: { "Content-Type": "multipart/form-data" },
   });
   return data;
+}
+
+export async function fetchReports(): Promise<ProblemReport[]> {
+  const { data } = await api.get("/reports");
+  return (data.items ?? data) as ProblemReport[];
+}
+
+export async function resolveReport(id: number) {
+  const { data } = await api.put(`/reports/${id}`, { resolve: true });
+  return data as ProblemReport;
 }


### PR DESCRIPTION
## Summary
- use logged-in user id when submitting reports
- refresh admin problem reports every 10s and map API fields to display data
- send admin replies as notifications and allow resolving reports

## Testing
- `go build ./...`
- `npm run lint` *(fails: Unexpected any and unused vars in existing files)*
- `npx eslint src/pages/Report/ReportPage.tsx src/pages/Admin/AdminPage.tsx src/interfaces/problem_report.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bff63521d48323bc022909d5bdbf76