### PR TITLE
Initialize ProductGrid game state with empty array

### DIFF
--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -45,7 +45,7 @@ const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
     return `${base_url}/${clean}`;
   };
 
-  const [game, Setgame] = useState<Game[] | null>(null);
+  const [game, Setgame] = useState<Game[]>([]);
   const navigate = useNavigate();
 
   async function GetGame() {
@@ -120,7 +120,7 @@ const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
     }
   }; 
 
-  const approveGames = game.filter(game => game.status === "approve");
+  const approveGames = (game ?? []).filter(game => game.status === "approve");
   return (
   <Row gutter={[16, 16]}> 
       {approveGames.map((c) => ( 


### PR DESCRIPTION
## Summary
- initialize `game` state with an empty array instead of null in `ProductGrid`
- guard approved games filtering with nullish coalescing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c007872dd88329abde844d62f7389b