### PR TITLE
Resolve FindGames preload conflict

### DIFF
--- a/backend/controllers/games.go
+++ b/backend/controllers/games.go
@@ -90,11 +90,8 @@ func FindGames(c *gin.Context) {
 	now := time.Now()
 	if err := configs.DB().
 		Preload("Categories").
-<<<<<<< HEAD
 		Preload("Promotions", "status = ? AND start_date <= ? AND end_date >= ?", true, now, now).
-=======
 		Preload("Requests").
->>>>>>> main
 		Find(&games).Error; err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
## Summary
- remove merge conflict markers in `FindGames`
- preload promotions and requests when listing games

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c00d363fec8329abee2be8f7dbcdcf