### PR TITLE
Integrate cart creation and payment order fetching

### DIFF
--- a/frontend/src/components/Payment.tsx
+++ b/frontend/src/components/Payment.tsx
@@ -14,7 +14,6 @@ import {
   message,
 } from "antd";
 import type { UploadFile } from "antd/es/upload/interface";
-import { useParams, useSearchParams } from "react-router-dom";
 
 // ✅ โทนเดียวกับหน้าอื่น
 const THEME_PRIMARY = "#9b59b6";
@@ -43,13 +42,7 @@ const PaymentPage = () => {
   const [payOpen, setPayOpen] = useState(false);
   const [files, setFiles] = useState<UploadFile[]>([]);
   const [submitting, setSubmitting] = useState(false);
-  const { id } = useParams();
-  const [searchParams] = useSearchParams();
-  const orderIdParam =
-    id ||
-    searchParams.get("id") ||
-    searchParams.get("order_id") ||
-    localStorage.getItem("orderId");
+  const orderIdParam = localStorage.getItem("orderId");
 
   useEffect(() => {
     if (!orderIdParam) return;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,12 +1,10 @@
 import Navbar from "../components/Navbar";
 import ProductGrid from "../components/ProductGrid";
-import { useAuth } from "../context/AuthContext";
 import { Button, Space, Typography } from "antd";
 
 const { Title } = Typography;
 
 const Home = () => {
-  const { userId } = useAuth();
   return (
     <div style={{ background: '#141414', flex: 1 , minHeight: '100vh'}}>
       <Navbar />
@@ -19,7 +17,7 @@ const Home = () => {
           <Button shape="round">Recommended</Button>
           <Button shape="round">Filter</Button>
         </Space>
-        <ProductGrid userId={userId} />
+        <ProductGrid />
       </div>
     </div>
   );

--- a/frontend/src/pages/Review/Mygame.tsx
+++ b/frontend/src/pages/Review/Mygame.tsx
@@ -1,13 +1,11 @@
 import { Layout, Space, Typography } from "antd";
 import Sidebar from "../../components/Sidebar";
 import ProductGrid from "../../components/ProductGrid"; // ใช้คอมโพเนนต์ที่มีอยู่จริง
-import { useAuth } from "../../context/AuthContext";
 
 const { Content } = Layout;
 const { Title } = Typography;
 
 const Mygame = () => {
-  const { userId } = useAuth();
   return (
     <Layout style={{ minHeight: "100vh", background: "#0f0f0f" }}>
       {/* Sidebar ทางซ้าย */}
@@ -33,7 +31,7 @@ const Mygame = () => {
           </Space>
 
           {/* UI-only: แสดงกริดเกมจากคอมโพเนนต์ที่มีอยู่แล้ว */}
-          <ProductGrid userId={userId} />
+          <ProductGrid />
         </div>
       </Content>
     </Layout>


### PR DESCRIPTION
## Summary
- fetch user id via `useAuth` in `ProductGrid` and handle cart creation/updating with backend orders
- compute order totals using line totals after adding items
- load order items on Payment page from saved `orderId` and show server-calculated `line_total`

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c052396a3c8322a459fdd3b97f2ae1