### PR TITLE
Ensure orders use authenticated user

### DIFF
--- a/backend/controllers/order.go
+++ b/backend/controllers/order.go
@@ -15,6 +15,16 @@ func CreateOrder(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
 		return
 	}
+	uid, err := getUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+	if body.UserID != 0 && body.UserID != uid {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "user_id mismatch"})
+		return
+	}
+	body.UserID = uid
 	// ตรวจ User
 	var user entity.User
 	if tx := configs.DB().First(&user, body.UserID); tx.RowsAffected == 0 {

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -4,12 +4,14 @@ import { useNavigate } from "react-router-dom";
 import { Card, Button } from "antd";
 import { useState, useEffect } from "react";
 import axios from "axios";
-import { useAuth } from "../context/AuthContext";
 
 const base_url = "http://localhost:8088";
 
-const ProductGrid: React.FC = () => {
-  const { id } = useAuth();
+interface ProductGridProps {
+  userId?: number;
+}
+
+const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
   interface Game {
     ID: number;
     game_name: string;
@@ -59,24 +61,24 @@ const ProductGrid: React.FC = () => {
     GetGame();
   }, []);
 
-  const handleAddToCart = async (g: Game) => {
-    if (!id) return; // ต้องเข้าสู่ระบบก่อนสั่งซื้อ
-    try {
-      const stored = localStorage.getItem("orderId");
-      if (!stored) {
-        // สร้างออร์เดอร์ใหม่พร้อมรายการแรก
-        const res = await axios.post(`${base_url}/orders`, {
-          user_id: id,
-          total_amount: g.base_price,
-          order_status: "PENDING",
-          order_items: [
-            {
-              unit_price: g.base_price,
-              qty: 1,
-              game_key_id: g.key_id,
-            },
-          ],
-        });
+    const handleAddToCart = async (g: Game) => {
+      if (!userId) return; // ต้องเข้าสู่ระบบก่อนสั่งซื้อ
+      try {
+        const stored = localStorage.getItem("orderId");
+        if (!stored) {
+          // สร้างออร์เดอร์ใหม่พร้อมรายการแรก
+          const res = await axios.post(`${base_url}/orders`, {
+            user_id: userId,
+            total_amount: g.base_price,
+            order_status: "PENDING",
+            order_items: [
+              {
+                unit_price: g.base_price,
+                qty: 1,
+                game_key_id: g.key_id,
+              },
+            ],
+          });
         const newId = res.data.ID || res.data.id;
         if (newId) {
           localStorage.setItem("orderId", String(newId));

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,10 +1,12 @@
 import Navbar from "../components/Navbar";
 import ProductGrid from "../components/ProductGrid";
 import { Button, Space, Typography } from "antd";
+import { useAuth } from "../context/AuthContext";
 
 const { Title } = Typography;
 
 const Home = () => {
+  const { id } = useAuth();
   return (
     <div style={{ background: '#141414', flex: 1 , minHeight: '100vh'}}>
       <Navbar />
@@ -17,7 +19,7 @@ const Home = () => {
           <Button shape="round">Recommended</Button>
           <Button shape="round">Filter</Button>
         </Space>
-        <ProductGrid />
+        <ProductGrid userId={id} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- retrieve auth id in Home and pass as userId to ProductGrid
- use userId prop in ProductGrid when creating orders
- validate UserID against JWT token in CreateOrder

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: multiple lint errors)
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0545bcf7883228ab27c25656ff7d8