### PR TITLE
Recompute order totals from game price and promotions

### DIFF
--- a/backend/controllers/order.go
+++ b/backend/controllers/order.go
@@ -20,11 +20,12 @@ func CreateOrder(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 		return
 	}
-	if body.UserID != 0 && body.UserID != uid {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "user_id mismatch"})
-		return
-	}
-	body.UserID = uid
+        if body.UserID != 0 && body.UserID != uid {
+                c.JSON(http.StatusUnauthorized, gin.H{"error": "user_id mismatch"})
+                return
+        }
+        body.UserID = uid
+        body.TotalAmount = 0
 	// ตรวจ User
 	var user entity.User
 	if tx := configs.DB().First(&user, body.UserID); tx.RowsAffected == 0 {

--- a/backend/controllers/order_item.go
+++ b/backend/controllers/order_item.go
@@ -10,120 +10,116 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// payload สำหรับสร้าง OrderItem โดยไม่ให้ผู้ใช้กำหนดส่วนลดเอง
+// payload สำหรับสร้าง OrderItem โดยให้ระบบคำนวณราคาเอง
 type createOrderItemRequest struct {
-	UnitPrice    float64  `json:"unit_price" binding:"required"`
-	QTY          int      `json:"qty" binding:"required"`
-	OrderID      uint     `json:"order_id" binding:"required"`
-	GameKeyID    *uint    `json:"game_key_id"`
-	LineDiscount *float64 `json:"line_discount"`
-	LineTotal    *float64 `json:"line_total"`
+        QTY       int   `json:"qty" binding:"required"`
+        OrderID   uint  `json:"order_id" binding:"required"`
+        GameKeyID *uint `json:"game_key_id" binding:"required"`
 }
 
 func CreateOrderItem(c *gin.Context) {
-	var body createOrderItemRequest
-	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
-		return
-	}
-	db := configs.DB()
+        var body createOrderItemRequest
+        if err := c.ShouldBindJSON(&body); err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
+                return
+        }
+        db := configs.DB()
 
-	// ตรวจ Order
-	var od entity.Order
-	if tx := db.First(&od, body.OrderID); tx.RowsAffected == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "order_id not found"})
-		return
-	}
+        // ตรวจ Order
+        var od entity.Order
+        if tx := db.First(&od, body.OrderID); tx.RowsAffected == 0 {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "order_id not found"})
+                return
+        }
 
-	// ตรวจ GameKey (ถ้าระบุ)
-	var gameID uint
-	if body.GameKeyID != nil {
-		var gk entity.KeyGame
-		if tx := db.First(&gk, *body.GameKeyID); tx.RowsAffected == 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "game_key_id not found"})
-			return
-		}
-		// ตรวจว่าคีย์เกมถูกใช้ไปแล้วหรือยัง (อาศัยคอลัมน์ order_item_id)
-		var cnt int64
-		db.Model(&entity.KeyGame{}).
-			Where("id = ? AND order_item_id IS NOT NULL", *body.GameKeyID).
-			Count(&cnt)
-		if cnt > 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "game key already assigned"})
-			return
-		}
-		gameID = gk.GameID
-	}
+        // ตรวจ GameKey
+        var gk entity.KeyGame
+        if tx := db.Preload("Game").First(&gk, *body.GameKeyID); tx.RowsAffected == 0 {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "game_key_id not found"})
+                return
+        }
+        // ตรวจว่าคีย์เกมถูกใช้ไปแล้วหรือยัง
+        var cnt int64
+        db.Model(&entity.KeyGame{}).
+                Where("id = ? AND order_item_id IS NOT NULL", *body.GameKeyID).
+                Count(&cnt)
+        if cnt > 0 {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "game key already assigned"})
+                return
+        }
+        gameID := gk.GameID
+        unitPrice := float64(gk.Game.BasePrice)
 
-	// หาส่วนลดจากโปรโมชั่นที่ผูกกับเกมหรือออร์เดอร์
-	sub := body.UnitPrice * float64(body.QTY)
-	discount := 0.0
+        // หาส่วนลดจากโปรโมชั่นที่ผูกกับเกมหรือออร์เดอร์
+        sub := unitPrice * float64(body.QTY)
+        discount := 0.0
 
-	now := time.Now()
-	var promos []entity.Promotion
-	// โปรโมชันจากเกม
-	if gameID != 0 {
-		var gamePromos []entity.Promotion
-		db.Joins("JOIN promotion_games pg ON pg.promotion_id = promotions.id").
-			Where("pg.game_id = ? AND promotions.status = 1 AND promotions.start_date <= ? AND promotions.end_date >= ?", gameID, now, now).
-			Find(&gamePromos)
-		promos = append(promos, gamePromos...)
-	}
-	// โปรโมชันจากออร์เดอร์
-	var orderPromos []entity.Promotion
-	db.Joins("JOIN order_promotions op ON op.promotion_id = promotions.id").
-		Where("op.order_id = ? AND promotions.status = 1 AND promotions.start_date <= ? AND promotions.end_date >= ?", body.OrderID, now, now).
-		Find(&orderPromos)
-	promos = append(promos, orderPromos...)
+        now := time.Now()
+        var promos []entity.Promotion
+        // โปรโมชันจากเกม
+        if gameID != 0 {
+                var gamePromos []entity.Promotion
+                db.Joins("JOIN promotion_games pg ON pg.promotion_id = promotions.id").
+                        Where("pg.game_id = ? AND promotions.status = 1 AND promotions.start_date <= ? AND "+
+                                "promotions.end_date >= ?", gameID, now, now).
+                        Find(&gamePromos)
+                promos = append(promos, gamePromos...)
+        }
+        // โปรโมชันจากออร์เดอร์
+        var orderPromos []entity.Promotion
+        db.Joins("JOIN order_promotions op ON op.promotion_id = promotions.id").
+                Where("op.order_id = ? AND promotions.status = 1 AND promotions.start_date <= ? AND "+
+                        "promotions.end_date >= ?", body.OrderID, now, now).
+                Find(&orderPromos)
+        promos = append(promos, orderPromos...)
 
-	for _, p := range promos {
-		var d float64
-		if p.DiscountType == entity.DiscountPercent {
-			d = sub * float64(p.DiscountValue) / 100
-		} else if p.DiscountType == entity.DiscountAmount {
-			d = float64(p.DiscountValue) * float64(body.QTY)
-		}
-		if d > discount {
-			discount = d
-		}
-	}
-	if discount > sub {
-		discount = sub
-	}
-	// ตรวจสอบถ้ามีส่ง line_discount/line_total มาต้องตรงกับที่คำนวณ
-	if body.LineDiscount != nil && math.Round(*body.LineDiscount*100)/100 != math.Round(discount*100)/100 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "line_discount mismatch"})
-		return
-	}
-	total := sub - discount
-	total = math.Round(total*100) / 100
-	if body.LineTotal != nil && math.Round(*body.LineTotal*100)/100 != total {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "line_total mismatch"})
-		return
-	}
+        for _, p := range promos {
+                var d float64
+                if p.DiscountType == entity.DiscountPercent {
+                        d = sub * float64(p.DiscountValue) / 100
+                } else if p.DiscountType == entity.DiscountAmount {
+                        d = float64(p.DiscountValue) * float64(body.QTY)
+                }
+                if d > discount {
+                        discount = d
+                }
+        }
+        if discount > sub {
+                discount = sub
+        }
 
-	item := entity.OrderItem{
-		UnitPrice:    body.UnitPrice,
-		QTY:          body.QTY,
-		LineDiscount: math.Round(discount*100) / 100,
-		LineTotal:    total,
-		OrderID:      body.OrderID,
-		GameKeyID:    body.GameKeyID,
-	}
+        total := sub - discount
+        total = math.Round(total*100) / 100
 
-	if err := db.Create(&item).Error; err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
+        item := entity.OrderItem{
+                UnitPrice:    unitPrice,
+                QTY:          body.QTY,
+                LineDiscount: math.Round(discount*100) / 100,
+                LineTotal:    total,
+                OrderID:      body.OrderID,
+                GameKeyID:    body.GameKeyID,
+        }
 
-	// ถ้าผูก GameKey ให้ตั้ง owner
-	if body.GameKeyID != nil {
-		db.Model(&entity.KeyGame{}).
-			Where("id = ?", *body.GameKeyID).
-			Update("order_item_id", item.ID)
-	}
+        if err := db.Create(&item).Error; err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+                return
+        }
 
-	c.JSON(http.StatusCreated, item)
+        // ผูก GameKey ให้ตั้ง owner
+        db.Model(&entity.KeyGame{}).
+                Where("id = ?", *body.GameKeyID).
+                Update("order_item_id", item.ID)
+
+        // อัปเดตราคารวมของออร์เดอร์
+        var sumTotal float64
+        db.Model(&entity.OrderItem{}).
+                Where("order_id = ?", body.OrderID).
+                Select("COALESCE(SUM(line_total),0)").Scan(&sumTotal)
+        db.Model(&entity.Order{}).
+                Where("id = ?", body.OrderID).
+                Update("total_amount", sumTotal)
+
+        c.JSON(http.StatusCreated, item)
 }
 
 func FindOrderItems(c *gin.Context) {

--- a/backend/controllers/order_test.go
+++ b/backend/controllers/order_test.go
@@ -1,0 +1,60 @@
+package controllers
+
+import (
+    "bytes"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "os"
+    "testing"
+    "time"
+
+    "example.com/sa-gameshop/configs"
+    "example.com/sa-gameshop/entity"
+    "github.com/gin-gonic/gin"
+    "github.com/golang-jwt/jwt/v5"
+)
+
+func TestCreateOrderTotalAmountIgnored(t *testing.T) {
+    os.Setenv("DB_PATH", "file::memory:?cache=shared")
+    configs.ConnectionDB()
+    db := configs.DB()
+    if err := db.AutoMigrate(&entity.User{}, &entity.Order{}); err != nil {
+        t.Fatalf("migrate failed: %v", err)
+    }
+
+    user := entity.User{Username: "tester"}
+    if err := db.Create(&user).Error; err != nil {
+        t.Fatalf("create user: %v", err)
+    }
+
+    gin.SetMode(gin.TestMode)
+    w := httptest.NewRecorder()
+    c, _ := gin.CreateTestContext(w)
+
+    payload := map[string]interface{}{
+        "total_amount": 999,
+    }
+    b, _ := json.Marshal(payload)
+    req := httptest.NewRequest(http.MethodPost, "/orders", bytes.NewReader(b))
+    req.Header.Set("Content-Type", "application/json")
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": float64(user.ID), "exp": time.Now().Add(time.Hour).Unix()})
+    tokenString, _ := token.SignedString([]byte("secret"))
+    req.Header.Set("Authorization", "Bearer "+tokenString)
+
+    c.Request = req
+
+    CreateOrder(c)
+
+    if w.Code != http.StatusCreated {
+        t.Fatalf("expected status 201, got %d", w.Code)
+    }
+    var resp entity.Order
+    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("invalid response: %v", err)
+    }
+    if resp.TotalAmount != 0 {
+        t.Fatalf("total_amount should be 0, got %v", resp.TotalAmount)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Fetch game base price in CreateOrderItem and compute discounts and totals server-side
- Update orders' total_amount by summing item line totals after each item creation
- Ignore total_amount in CreateOrder, defaulting to zero

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0c89e55ec832287777ad6ace3a0df