### PR TITLE
fix: send minimal order item payload

### DIFF
--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -88,9 +88,10 @@ const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
           const total =
             orderRes.data.total_amount ??
             (orderRes.data.order_items || []).reduce(
-              (sum: number, it: any) => sum + Number(it.line_total),
-              0
-            );
+          (sum: number, it: { line_total: number }) =>
+            sum + Number(it.line_total),
+          0
+        );
           await axios.put(`${base_url}/orders/${newId}`, {
             total_amount: total,
           });
@@ -101,13 +102,13 @@ const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
           order_id: Number(stored),
           game_key_id: g.key_id,
           qty: 1,
-          unit_price: unitPrice,
         });
         const orderRes = await axios.get(`${base_url}/orders/${stored}`);
         const total =
           orderRes.data.total_amount ??
           (orderRes.data.order_items || []).reduce(
-            (sum: number, it: any) => sum + Number(it.line_total),
+            (sum: number, it: { line_total: number }) =>
+              sum + Number(it.line_total),
             0
           );
         await axios.put(`${base_url}/orders/${stored}`, { total_amount: total });


### PR DESCRIPTION
## Summary
- send only order_id, game_key_id and qty when adding items to an existing order
- type order item line totals to remove `any`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 35 problems, 34 errors, 1 warning)*
- `npx eslint src/components/ProductGrid.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c0d0413fc8832292d0f6df5c79de3e