### PR TITLE
Add checkout endpoint for game payments

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -129,6 +129,7 @@ func main() {
 
 		// ===== Payments =====
 		router.POST("/payments", controllers.CreatePayment)
+		router.POST("/payments/checkout", controllers.CreatePaymentWithGames)
 		router.GET("/payments", controllers.FindPayments)
 		router.PATCH("/payments/:id", controllers.UpdatePayment)
 		router.DELETE("/payments/:id", controllers.DeletePayment)


### PR DESCRIPTION
## Summary
- add `CreatePaymentWithGames` controller to build orders for a user, apply game promotions and total pricing
- expose new `/payments/checkout` route for purchasing multiple games in a single order

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0daadf7488322981b45f5e173ed12