### PR TITLE
Add checkout endpoint for game payments

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -129,6 +129,7 @@ func main() {
 
 		// ===== Payments =====
 		router.POST("/payments", controllers.CreatePayment)
+		router.POST("/payments/checkout", controllers.CreatePaymentWithGames)
 		router.GET("/payments", controllers.FindPayments)
 		router.PATCH("/payments/:id", controllers.UpdatePayment)
 		router.DELETE("/payments/:id", controllers.DeletePayment)

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -64,14 +64,17 @@ const ProductGrid: React.FC<ProductGridProps> = ({ userId }) => {
   const handleAddToCart = async (g: Game) => {
     try {
       const price = g.discounted_price ?? g.base_price;
+      const discount = g.base_price - price;
       const res = await axios.post(`${base_url}/orders`, {
         user_id: 1,
         total_amount: price,
         order_status: "PENDING",
         order_items: [
           {
-            unit_price: price,
+            unit_price: g.base_price,
             qty: 1,
+            line_discount: discount,
+            line_total: price,
             game_key_id: g.key_id,
           },
         ],


### PR DESCRIPTION
## Summary
- add `CreatePaymentWithGames` controller to build orders for a user, apply game promotions and total pricing
- expose new `/payments/checkout` route for purchasing multiple games in a single order
- include line totals and discounts when adding cart items so checkout shows correct prices

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*
- `npm run build` *(fails: existing TypeScript errors)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0daadf7488322981b45f5e173ed12