### PR TITLE
Support multi-item orders and user association

### DIFF
--- a/backend/controllers/order.go
+++ b/backend/controllers/order.go
@@ -24,6 +24,14 @@ func CreateOrder(c *gin.Context) {
 	if body.OrderCreate.IsZero() {
 		body.OrderCreate = time.Now()
 	}
+	// ถ้ามีรายการสินค้า ให้คำนวณราคารวมจากยอดสุทธิของแต่ละรายการ
+	total := 0.0
+	for _, it := range body.OrderItems {
+		total += it.LineTotal
+	}
+	if total > 0 {
+		body.TotalAmount = total
+	}
 	if err := configs.DB().Create(&body).Error; err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/backend/controllers/order_item.go
+++ b/backend/controllers/order_item.go
@@ -8,16 +8,15 @@ import (
 	"example.com/sa-gameshop/configs"
 	"example.com/sa-gameshop/entity"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // payload สำหรับสร้าง OrderItem โดยไม่ให้ผู้ใช้กำหนดส่วนลดเอง
 type createOrderItemRequest struct {
-	UnitPrice    float64  `json:"unit_price" binding:"required"`
-	QTY          int      `json:"qty" binding:"required"`
-	OrderID      uint     `json:"order_id" binding:"required"`
-	GameKeyID    *uint    `json:"game_key_id"`
-	LineDiscount *float64 `json:"line_discount"`
-	LineTotal    *float64 `json:"line_total"`
+	UnitPrice float64 `json:"unit_price" binding:"required"`
+	QTY       int     `json:"qty" binding:"required"`
+	OrderID   uint    `json:"order_id" binding:"required"`
+	GameKeyID *uint   `json:"game_key_id"`
 }
 
 func CreateOrderItem(c *gin.Context) {
@@ -90,17 +89,8 @@ func CreateOrderItem(c *gin.Context) {
 	if discount > sub {
 		discount = sub
 	}
-	// ตรวจสอบถ้ามีส่ง line_discount/line_total มาต้องตรงกับที่คำนวณ
-	if body.LineDiscount != nil && math.Round(*body.LineDiscount*100)/100 != math.Round(discount*100)/100 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "line_discount mismatch"})
-		return
-	}
 	total := sub - discount
 	total = math.Round(total*100) / 100
-	if body.LineTotal != nil && math.Round(*body.LineTotal*100)/100 != total {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "line_total mismatch"})
-		return
-	}
 
 	item := entity.OrderItem{
 		UnitPrice:    body.UnitPrice,
@@ -122,6 +112,11 @@ func CreateOrderItem(c *gin.Context) {
 			Where("id = ?", *body.GameKeyID).
 			Update("order_item_id", item.ID)
 	}
+
+	// อัปเดตราคารวมของออร์เดอร์หลังเพิ่มรายการใหม่
+	db.Model(&entity.Order{}).
+		Where("id = ?", body.OrderID).
+		Update("total_amount", gorm.Expr("total_amount + ?", item.LineTotal))
 
 	c.JSON(http.StatusCreated, item)
 }
@@ -162,11 +157,22 @@ func UpdateOrderItem(c *gin.Context) {
 func DeleteOrderItem(c *gin.Context) {
 	// เคลียร์การอ้างอิง GameKey ก่อน
 	db := configs.DB()
+	var item entity.OrderItem
+	if tx := db.First(&item, c.Param("id")); tx.RowsAffected == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "id not found"})
+		return
+	}
+
 	db.Model(&entity.KeyGame{}).Where("order_item_id = ?", c.Param("id")).Update("order_item_id", nil)
 
 	if tx := db.Exec("DELETE FROM order_items WHERE id = ?", c.Param("id")); tx.RowsAffected == 0 {
 		c.JSON(http.StatusNotFound, gin.H{"error": "id not found"})
 		return
 	}
+
+	db.Model(&entity.Order{}).
+		Where("id = ?", item.OrderID).
+		Update("total_amount", gorm.Expr("total_amount - ?", item.LineTotal))
+
 	c.JSON(http.StatusOK, gin.H{"message": "deleted successful"})
 }


### PR DESCRIPTION
## Summary
- compute order item totals on the server and update order automatically
- ensure frontend cart creates an order once and adds items without client-calculated prices

## Testing
- `go build ./...` *(fails: process hung, interrupted)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 36 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e0ac83bc83229b4b83d1c8c64d33