### PR TITLE
Restrict user order visibility

### DIFF
--- a/backend/controllers/order.go
+++ b/backend/controllers/order.go
@@ -1,12 +1,16 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"example.com/sa-gameshop/configs"
 	"example.com/sa-gameshop/entity"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func CreateOrder(c *gin.Context) {
@@ -32,12 +36,21 @@ func CreateOrder(c *gin.Context) {
 }
 
 func FindOrders(c *gin.Context) {
+	user, err := authorize(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
 	var rows []entity.Order
 	db := configs.DB().Preload("User").Preload("OrderItems").Preload("Payments").Preload("OrderPromotions")
-	userID := c.Query("user_id")
 	status := c.Query("status")
-	if userID != "" {
-		db = db.Where("user_id = ?", userID)
+	if user.RoleID == 3 {
+		userID := c.Query("user_id")
+		if userID != "" {
+			db = db.Where("user_id = ?", userID)
+		}
+	} else {
+		db = db.Where("user_id = ?", user.ID)
 	}
 	if status != "" {
 		db = db.Where("order_status = ?", status)
@@ -50,6 +63,11 @@ func FindOrders(c *gin.Context) {
 }
 
 func FindOrderByID(c *gin.Context) {
+	user, err := authorize(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
 	var row entity.Order
 	if tx := configs.DB().
 		Preload("User").
@@ -58,6 +76,10 @@ func FindOrderByID(c *gin.Context) {
 		Preload("OrderPromotions.Promotion").
 		First(&row, c.Param("id")); tx.RowsAffected == 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "id not found"})
+		return
+	}
+	if user.RoleID != 3 && row.UserID != user.ID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
 	}
 	c.JSON(http.StatusOK, row)
@@ -88,4 +110,38 @@ func DeleteOrder(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "deleted successful"})
+}
+
+func authorize(c *gin.Context) (*entity.User, error) {
+	header := c.GetHeader("Authorization")
+	if header == "" {
+		return nil, errors.New("authorization header missing")
+	}
+	tokenString := strings.TrimPrefix(header, "Bearer ")
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		secret = "secret"
+	}
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(secret), nil
+	})
+	if err != nil || !token.Valid {
+		return nil, errors.New("invalid token")
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("invalid claims")
+	}
+	sub, ok := claims["sub"].(float64)
+	if !ok {
+		return nil, errors.New("invalid subject")
+	}
+	var user entity.User
+	if tx := configs.DB().First(&user, uint(sub)); tx.RowsAffected == 0 {
+		return nil, errors.New("user not found")
+	}
+	return &user, nil
 }


### PR DESCRIPTION
## Summary
- enforce authorization on order endpoints
- allow admins to view all orders while users see only their own

## Testing
- `go build ./...` *(fails: command hangs in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68c0f0bb362c8322b730dc84c6dfe6cf