### PR TITLE
Restrict user order visibility

### DIFF
--- a/backend/controllers/order.go
+++ b/backend/controllers/order.go
@@ -1,26 +1,30 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"example.com/sa-gameshop/configs"
 	"example.com/sa-gameshop/entity"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func CreateOrder(c *gin.Context) {
+	user, err := authorize(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
 	var body entity.Order
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
 		return
 	}
-	// ตรวจ User
-	var user entity.User
-	if tx := configs.DB().First(&user, body.UserID); tx.RowsAffected == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id not found"})
-		return
-	}
+	body.UserID = user.ID
 	if body.OrderCreate.IsZero() {
 		body.OrderCreate = time.Now()
 	}
@@ -32,12 +36,23 @@ func CreateOrder(c *gin.Context) {
 }
 
 func FindOrders(c *gin.Context) {
+	user, err := authorize(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
 	var rows []entity.Order
 	db := configs.DB().Preload("User").Preload("OrderItems").Preload("Payments").Preload("OrderPromotions")
-	userID := c.Query("user_id")
 	status := c.Query("status")
-	if userID != "" {
-		db = db.Where("user_id = ?", userID)
+	if user.RoleID == 3 {
+		userID := c.Query("user_id")
+		if userID != "" {
+			db = db.Where("user_id = ?", userID)
+		} else {
+			db = db.Where("user_id = ?", user.ID)
+		}
+	} else {
+		db = db.Where("user_id = ?", user.ID)
 	}
 	if status != "" {
 		db = db.Where("order_status = ?", status)
@@ -50,6 +65,11 @@ func FindOrders(c *gin.Context) {
 }
 
 func FindOrderByID(c *gin.Context) {
+	user, err := authorize(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
 	var row entity.Order
 	if tx := configs.DB().
 		Preload("User").
@@ -60,10 +80,19 @@ func FindOrderByID(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "id not found"})
 		return
 	}
+	if user.RoleID != 3 && row.UserID != user.ID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
 	c.JSON(http.StatusOK, row)
 }
 
 func UpdateOrder(c *gin.Context) {
+	user, err := authorize(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
 	var payload entity.Order
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -75,6 +104,10 @@ func UpdateOrder(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "id not found"})
 		return
 	}
+	if user.RoleID != 3 && row.UserID != user.ID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
 	if err := db.Model(&row).Updates(payload).Error; err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -83,9 +116,58 @@ func UpdateOrder(c *gin.Context) {
 }
 
 func DeleteOrder(c *gin.Context) {
-	if tx := configs.DB().Exec("DELETE FROM orders WHERE id = ?", c.Param("id")); tx.RowsAffected == 0 {
+	user, err := authorize(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+	var row entity.Order
+	db := configs.DB()
+	if tx := db.First(&row, c.Param("id")); tx.RowsAffected == 0 {
 		c.JSON(http.StatusNotFound, gin.H{"error": "id not found"})
 		return
 	}
+	if user.RoleID != 3 && row.UserID != user.ID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+	if err := db.Delete(&row).Error; err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"message": "deleted successful"})
+}
+
+func authorize(c *gin.Context) (*entity.User, error) {
+	header := c.GetHeader("Authorization")
+	if header == "" {
+		return nil, errors.New("authorization header missing")
+	}
+	tokenString := strings.TrimPrefix(header, "Bearer ")
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		secret = "secret"
+	}
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(secret), nil
+	})
+	if err != nil || !token.Valid {
+		return nil, errors.New("invalid token")
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("invalid claims")
+	}
+	sub, ok := claims["sub"].(float64)
+	if !ok {
+		return nil, errors.New("invalid subject")
+	}
+	var user entity.User
+	if tx := configs.DB().First(&user, uint(sub)); tx.RowsAffected == 0 {
+		return nil, errors.New("user not found")
+	}
+	return &user, nil
 }


### PR DESCRIPTION
## Summary
- enforce current user on order creation
- default order listing to authenticated user unless admin filters by user_id
- block updates/deletes when requester is neither owner nor admin

## Testing
- `go build ./...` *(fails: command hangs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f0bb362c8322b730dc84c6dfe6cf