### PR TITLE
Authorize payment creation

### DIFF
--- a/backend/controllers/payment.go
+++ b/backend/controllers/payment.go
@@ -15,6 +15,11 @@ import (
 )
 
 func CreatePayment(c *gin.Context) {
+	user, err := authorize(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
 	var body entity.Payment
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
@@ -24,6 +29,10 @@ func CreatePayment(c *gin.Context) {
 	var od entity.Order
 	if tx := configs.DB().First(&od, body.OrderID); tx.RowsAffected == 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "order_id not found"})
+		return
+	}
+	if user.RoleID != 3 && od.UserID != user.ID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
 	}
 	if body.PaymentDate.IsZero() {


### PR DESCRIPTION
## Summary
- require authentication before creating a payment
- ensure user owns the order when creating payments

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c114e244cc8322a991dfadc73fe6f3