### PR TITLE
Compute order total from items

### DIFF
--- a/backend/controllers/order.go
+++ b/backend/controllers/order.go
@@ -32,6 +32,12 @@ func CreateOrder(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	total, err := updateOrderTotal(body.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	body.TotalAmount = total
 	c.JSON(http.StatusCreated, body)
 }
 
@@ -108,6 +114,10 @@ func UpdateOrder(c *gin.Context) {
 	}
 	if err := db.Model(&row).Updates(payload).Error; err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if _, err := updateOrderTotal(row.ID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "updated successful"})

--- a/backend/controllers/order_total.go
+++ b/backend/controllers/order_total.go
@@ -1,0 +1,26 @@
+package controllers
+
+import (
+	"math"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+)
+
+// updateOrderTotal recalculates the total amount for the given order ID
+// by summing line totals from order_items and updating the order record.
+func updateOrderTotal(orderID uint) (float64, error) {
+	db := configs.DB()
+	var total float64
+	if err := db.Model(&entity.OrderItem{}).
+		Where("order_id = ?", orderID).
+		Select("COALESCE(SUM(line_total),0)").
+		Scan(&total).Error; err != nil {
+		return 0, err
+	}
+	total = math.Round(total*100) / 100
+	if err := db.Model(&entity.Order{}).Where("id = ?", orderID).Update("total_amount", total).Error; err != nil {
+		return 0, err
+	}
+	return total, nil
+}

--- a/backend/controllers/payment.go
+++ b/backend/controllers/payment.go
@@ -75,8 +75,6 @@ func CreatePaymentWithGames(c *gin.Context) {
 		return
 	}
 
-	total := 0.0
-
 	for _, g := range req.Games {
 		qty := g.Quantity
 		if qty <= 0 {
@@ -113,7 +111,6 @@ func CreatePaymentWithGames(c *gin.Context) {
 		lineTotal := (unitPrice - discount) * float64(qty)
 		lineDiscount = math.Round(lineDiscount*100) / 100
 		lineTotal = math.Round(lineTotal*100) / 100
-		total += lineTotal
 
 		item := entity.OrderItem{
 			UnitPrice:    unitPrice,
@@ -128,8 +125,11 @@ func CreatePaymentWithGames(c *gin.Context) {
 		}
 	}
 
-	total = math.Round(total*100) / 100
-	db.Model(&order).Update("total_amount", total)
+	total, err := updateOrderTotal(order.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 
 	payment := entity.Payment{
 		OrderID:     order.ID,

--- a/frontend/src/interfaces/Order.ts
+++ b/frontend/src/interfaces/Order.ts
@@ -18,7 +18,6 @@ export interface Order {
 }
 
 export interface CreateOrderRequest {
-  total_amount: number;
   order_status: string;
   user_id: number;
   order_create?: string; // ถ้าไม่ส่ง backend จะใส่ให้
@@ -26,7 +25,6 @@ export interface CreateOrderRequest {
 
 export interface UpdateOrderRequest {
   ID: number;
-  total_amount?: number;
   order_status?: string;
   order_create?: string;
 }


### PR DESCRIPTION
## Summary
- derive order total_amount from related order_items on creation and updates
- remove total_amount from CreateOrderRequest so frontend no longer sends it

## Testing
- `go test ./...` *(hangs, no output)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68c11630cdb083228de4fa560e44822d