### PR TITLE
feat: add user-readable notifications

### DIFF
--- a/backend/controllers/notification.go
+++ b/backend/controllers/notification.go
@@ -12,11 +12,11 @@ import (
 
 // POST /notifications
 func CreateNotification(c *gin.Context) {
-	var body entity.Notification
-	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request body"})
-		return
-	}
+        var body entity.Notification
+        if err := c.ShouldBindJSON(&body); err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "bad request body"})
+                return
+        }
 
 	// ตรวจสอบว่ามี user_id นี้จริงไหม
 	var user entity.User
@@ -25,10 +25,12 @@ func CreateNotification(c *gin.Context) {
 		return
 	}
 
-	// default type ถ้าไม่ส่งมา
-	if body.Type == "" {
-		body.Type = "system"
-	}
+       // default type ถ้าไม่ส่งมา
+       if body.Type == "" {
+               body.Type = "system"
+       }
+       // เริ่มต้นให้ยังไม่อ่าน
+       body.IsRead = false
 
 	if err := configs.DB().Create(&body).Error; err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -88,12 +90,13 @@ func UpdateNotification(c *gin.Context) {
 		return
 	}
 
-	if err := db.Model(&row).Updates(payload).Error; err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
+       if err := db.Model(&row).Updates(payload).Error; err != nil {
+               c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+               return
+       }
 
-	c.JSON(http.StatusOK, gin.H{"message": "updated successfully"})
+       _ = db.First(&row, row.ID)
+       c.JSON(http.StatusOK, row)
 }
 
 // DELETE /notifications/:id

--- a/backend/controllers/problem_report.go
+++ b/backend/controllers/problem_report.go
@@ -281,12 +281,17 @@ func ReplyReport(c *gin.Context) {
 		}
 	}
 
-	// ✅ mark ว่าแก้ไขแล้ว
-	if text != "" {
-		// (คุณจะเลือกเก็บ text เป็น Notification หรือ Log ก็ได้)
-	}
-	rp.Status = "resolved"
-	rp.ResolvedAt = time.Now()
+       // ✅ mark ว่าแก้ไขแล้ว
+       if text != "" {
+               _ = db.Create(&entity.Notification{
+                       Title:   "ตอบกลับการรายงาน",
+                       Message: text,
+                       Type:    "report_reply",
+                       UserID:  rp.UserID,
+               }).Error
+       }
+       rp.Status = "resolved"
+       rp.ResolvedAt = time.Now()
 
 	if err := db.Save(&rp).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/backend/entity/notification.go
+++ b/backend/entity/notification.go
@@ -5,10 +5,12 @@ import (
 )
 
 type Notification struct {
-	gorm.Model
-	Title   string `json:"title"`
-	Type    string `json:"type"`    // e.g. "payment", "system", ...
-	Message string `json:"message"`
-	UserID  uint   `json:"user_id"`
-	User    *User  `gorm:"foreignKey:UserID" json:"user"`
+        gorm.Model
+        Title   string `json:"title"`
+        Type    string `json:"type"`    // e.g. "payment", "system", ...
+        Message string `json:"message"`
+        UserID  uint   `json:"user_id"`
+        User    *User  `gorm:"foreignKey:UserID" json:"user"`
+
+        IsRead bool `json:"is_read" gorm:"default:false"`
 }

--- a/frontend/src/components/NotificationsBell.tsx
+++ b/frontend/src/components/NotificationsBell.tsx
@@ -2,7 +2,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { Badge, Popover, List, Button, Typography } from "antd";
 import { BellOutlined } from "@ant-design/icons";
-import { fetchNotifications, markAllNotificationsRead } from "../services/Notification";
+import {
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  deleteNotification,
+} from "../services/Notification";
 import type { Notification } from "../interfaces/Notification";
 
 const { Text } = Typography;
@@ -38,11 +43,17 @@ export default function NotificationBell({ userId, pollMs = 5000 }: Props) {
 
   const onOpenChange = async (v: boolean) => {
     setOpen(v);
-    if (v && unreadCount > 0) {
-      await markAllNotificationsRead(userId);
-      // โหลดใหม่เพื่ออัปเดต badge = 0
-      await load();
-    }
+    if (v) await load();
+  };
+
+  const handleRead = async (id: number) => {
+    await markNotificationRead(id);
+    await load();
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteNotification(id);
+    await load();
   };
 
   const content = (
@@ -53,27 +64,44 @@ export default function NotificationBell({ userId, pollMs = 5000 }: Props) {
           ทำเป็นอ่านแล้วทั้งหมด
         </Button>
       </div>
-      <List
-        dataSource={items}
-        locale={{ emptyText: "ยังไม่มีการแจ้งเตือน" }}
-        renderItem={(n) => (
-          <List.Item style={{ background: n.is_read ? "transparent" : "rgba(146,84,222,0.12)", borderRadius: 8, marginBottom: 6, padding: "10px 12px" }}>
-            <List.Item.Meta
-              title={<Text strong>{n.title || "แจ้งเตือน"}</Text>}
-              description={
-                <div>
-                  <div>{n.message}</div>
-                  {!!n.created_at && (
-                    <Text type="secondary" style={{ fontSize: 12 }}>
-                      {new Date(n.created_at).toLocaleString()}
-                    </Text>
-                  )}
-                </div>
-              }
-            />
-          </List.Item>
-        )}
-      />
+        <List
+          dataSource={items}
+          locale={{ emptyText: "ยังไม่มีการแจ้งเตือน" }}
+          renderItem={(n) => (
+            <List.Item
+              style={{
+                background: n.is_read ? "transparent" : "rgba(146,84,222,0.12)",
+                borderRadius: 8,
+                marginBottom: 6,
+                padding: "10px 12px",
+              }}
+              actions={[
+                !n.is_read ? (
+                  <Button size="small" type="link" onClick={() => handleRead(n.ID)}>
+                    อ่านแล้ว
+                  </Button>
+                ) : null,
+                <Button size="small" danger type="link" onClick={() => handleDelete(n.ID)}>
+                  ลบ
+                </Button>,
+              ].filter(Boolean)}
+            >
+              <List.Item.Meta
+                title={<Text strong>{n.title || "แจ้งเตือน"}</Text>}
+                description={
+                  <div>
+                    <div>{n.message}</div>
+                    {!!n.created_at && (
+                      <Text type="secondary" style={{ fontSize: 12 }}>
+                        {new Date(n.created_at).toLocaleString()}
+                      </Text>
+                    )}
+                  </div>
+                }
+              />
+            </List.Item>
+          )}
+        />
     </div>
   );
 

--- a/frontend/src/services/Notification.ts
+++ b/frontend/src/services/Notification.ts
@@ -1,14 +1,32 @@
 // src/services/Notification.ts
 import api from "../lib/api";
 import type { Notification, CreateNotificationRequest } from "../interfaces/Notification";
+import type { User } from "../interfaces/User";
 
 // ดึงแจ้งเตือน (ผู้ใช้คนเดียว)
+interface RawNotification {
+  ID?: number;
+  title?: string;
+  Title?: string;
+  message?: string;
+  Message?: string;
+  type?: string;
+  Type?: string;
+  user_id?: number;
+  UserID?: number;
+  created_at?: string;
+  CreatedAt?: string;
+  is_read?: boolean;
+  IsRead?: boolean;
+  user?: User;
+  User?: User;
+}
+
 export async function fetchNotifications(userId: number): Promise<Notification[]> {
   const { data } = await api.get("/notifications", { params: { user_id: userId } });
-  // backend ของคุณคืนชื่อฟิลด์แบบ PascalCase/camelCase ปนกัน
-  // map ให้เป็นรูปแบบเดียว
-  return (data as any[]).map((n) => ({
-    ID: n.ID,
+  const list = data as RawNotification[];
+  return list.map((n) => ({
+    ID: n.ID ?? 0,
     title: n.title ?? n.Title ?? "",
     message: n.message ?? n.Message ?? "",
     type: n.type ?? n.Type ?? "",
@@ -36,4 +54,9 @@ export async function markAllNotificationsRead(userId: number): Promise<void> {
   const list = await fetchNotifications(userId);
   const unread = list.filter((n) => !n.is_read);
   await Promise.all(unread.map((n) => markNotificationRead(n.ID)));
+}
+
+// ลบแจ้งเตือน
+export async function deleteNotification(id: number): Promise<void> {
+  await api.delete(`/notifications/${id}`);
 }


### PR DESCRIPTION
## Summary
- add `is_read` field to notifications and return updated item on update
- notify report owner when admin replies
- allow users to mark and delete notifications in UI

## Testing
- `go test ./...` (fails: no such cache mode: shared?_busy_timeout=5000)
- `npm run lint` (fails: 43 errors, 2 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c1378efa34832393d32530714a0d64