### PR TITLE
Use Ant Design Plus icon in review section

### DIFF
--- a/frontend/src/components/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { ReviewsAPI, type Review } from "../services/reviews";
 import { Avatar, Button, Form, Input, List, Modal, Popconfirm, Rate, Space, message } from "antd";
-import { Heart, Pencil, Trash2, Plus } from "lucide-react";
-import { UserOutlined } from "@ant-design/icons";
+import { Heart, Pencil, Trash2 } from "lucide-react";
+import { UserOutlined, PlusOutlined } from "@ant-design/icons";
 import { useAuth } from "../context/AuthContext";
 
 export type ReviewSectionProps = {


### PR DESCRIPTION
## Summary
- import PlusOutlined from `@ant-design/icons`
- remove unused lucide-react Plus icon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68c14980d95883298fa3d984bed6398e