### PR TITLE
Link order items to games and key keys

### DIFF
--- a/backend/controllers/order.go
+++ b/backend/controllers/order.go
@@ -42,7 +42,12 @@ func FindOrders(c *gin.Context) {
 		return
 	}
 	var rows []entity.Order
-	db := configs.DB().Preload("User").Preload("OrderItems").Preload("Payments").Preload("OrderPromotions")
+	db := configs.DB().
+		Preload("User").
+		Preload("OrderItems.Game").
+		Preload("OrderItems.KeyGames").
+		Preload("Payments").
+		Preload("OrderPromotions")
 	status := c.Query("status")
 	if user.RoleID == 3 {
 		userID := c.Query("user_id")
@@ -71,7 +76,8 @@ func FindOrderByID(c *gin.Context) {
 	var row entity.Order
 	if tx := configs.DB().
 		Preload("User").
-		Preload("OrderItems.KeyGame.Game").
+		Preload("OrderItems.Game").
+		Preload("OrderItems.KeyGames").
 		Preload("Payments.PaymentSlips").
 		Preload("OrderPromotions.Promotion").
 		First(&row, c.Param("id")); tx.RowsAffected == 0 {

--- a/backend/controllers/payment.go
+++ b/backend/controllers/payment.go
@@ -115,6 +115,7 @@ func CreatePaymentWithGames(c *gin.Context) {
 			LineDiscount: lineDiscount,
 			LineTotal:    lineTotal,
 			OrderID:      order.ID,
+			GameID:       g.GameID,
 		}
 		if err := db.Create(&item).Error; err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -136,7 +137,7 @@ func CreatePaymentWithGames(c *gin.Context) {
 		return
 	}
 
-	db.Preload("OrderItems").First(&order, order.ID)
+	db.Preload("OrderItems.Game").Preload("OrderItems.KeyGames").First(&order, order.ID)
 
 	c.JSON(http.StatusCreated, gin.H{"order": order, "payment": payment})
 }

--- a/backend/entity/order_item.go
+++ b/backend/entity/order_item.go
@@ -5,15 +5,16 @@ import "gorm.io/gorm"
 
 type OrderItem struct {
 	gorm.Model
-	UnitPrice   float64 `json:"unit_price"`
-	QTY         int     `json:"qty"`
+	UnitPrice    float64 `json:"unit_price"`
+	QTY          int     `json:"qty"`
 	LineDiscount float64 `json:"line_discount"`
-	LineTotal   float64 `json:"line_total"`
+	LineTotal    float64 `json:"line_total"`
 
 	OrderID uint   `json:"order_id"`
 	Order   *Order `gorm:"foreignKey:OrderID" json:"order,omitempty"`
 
-	// ผูกคีย์เกมที่เบิกให้รายการนี้ (ถ้ามี)
-	GameKeyID *uint    `json:"game_key_id"`
-	KeyGame   *KeyGame `gorm:"foreignKey:GameKeyID" json:"key_game,omitempty"`
+	GameID uint  `json:"game_id"`
+	Game   *Game `gorm:"foreignKey:GameID" json:"game,omitempty"`
+
+	KeyGames []KeyGame `gorm:"foreignKey:OrderItemID" json:"key_games,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Link OrderItem to Game via GameID and preload keys via KeyGames
- Update order and payment controllers to load Game and KeyGames
- Support fetching Game and KeyGames when listing order items

## Testing
- `go test ./entity`
- `go vet ./...` *(fails: hung; aborted)*
- `go test ./...` *(fails: hung; aborted)*
- `go run .` *(fails: hung; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c14abad308832281f0d64c4711bf98