### PR TITLE
refactor: centralize discount and total calculation

### DIFF
--- a/backend/controllers/pricing.go
+++ b/backend/controllers/pricing.go
@@ -1,0 +1,65 @@
+package controllers
+
+import (
+	"errors"
+	"math"
+	"time"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+)
+
+// calculateLineTotal คำนวณราคาต่อเกมรวมถึงส่วนลดจากโปรโมชัน
+// หาก orderID เป็น 0 จะไม่นำโปรโมชันที่ผูกกับออร์เดอร์มาคำนวณ
+func calculateLineTotal(gameID uint, qty int, orderID uint) (unitPrice float64, lineDiscount float64, lineTotal float64, err error) {
+	db := configs.DB()
+
+	if qty <= 0 {
+		qty = 1
+	}
+
+	var game entity.Game
+	if tx := db.First(&game, gameID); tx.RowsAffected == 0 {
+		return 0, 0, 0, errors.New("game_id not found")
+	}
+	unitPrice = float64(game.BasePrice)
+	sub := unitPrice * float64(qty)
+
+	discount := 0.0
+	now := time.Now()
+	var promos []entity.Promotion
+
+	// promotions from game
+	db.Joins("JOIN promotion_games pg ON pg.promotion_id = promotions.id").
+		Where("pg.game_id = ? AND promotions.status = 1 AND promotions.start_date <= ? AND promotions.end_date >= ?", gameID, now, now).
+		Find(&promos)
+
+	// promotions from order
+	if orderID > 0 {
+		var orderPromos []entity.Promotion
+		db.Joins("JOIN order_promotions op ON op.promotion_id = promotions.id").
+			Where("op.order_id = ? AND promotions.status = 1 AND promotions.start_date <= ? AND promotions.end_date >= ?", orderID, now, now).
+			Find(&orderPromos)
+		promos = append(promos, orderPromos...)
+	}
+
+	for _, p := range promos {
+		var d float64
+		if p.DiscountType == entity.DiscountPercent {
+			d = sub * float64(p.DiscountValue) / 100
+		} else if p.DiscountType == entity.DiscountAmount {
+			d = float64(p.DiscountValue) * float64(qty)
+		}
+		if d > discount {
+			discount = d
+		}
+	}
+	if discount > sub {
+		discount = sub
+	}
+
+	lineTotal = sub - discount
+	lineDiscount = math.Round(discount*100) / 100
+	lineTotal = math.Round(lineTotal*100) / 100
+	return
+}

--- a/backend/controllers/pricing_test.go
+++ b/backend/controllers/pricing_test.go
@@ -1,0 +1,54 @@
+package controllers
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+)
+
+func TestCalculateLineTotal_PercentPromotion(t *testing.T) {
+	os.Setenv("DB_PATH", ":memory:")
+	configs.ConnectionDB()
+	db := configs.DB()
+	db.Exec("PRAGMA foreign_keys = OFF")
+	if err := db.AutoMigrate(&entity.Game{}, &entity.Promotion{}, &entity.Promotion_Game{}, &entity.KeyGame{}); err != nil {
+		t.Fatalf("migrate failed: %v", err)
+	}
+
+	game := entity.Game{GameName: "Test", BasePrice: 100}
+	if err := db.Create(&game).Error; err != nil {
+		t.Fatalf("create game failed: %v", err)
+	}
+
+	promo := entity.Promotion{
+		Title:         "Sale10",
+		DiscountType:  entity.DiscountPercent,
+		DiscountValue: 10,
+		StartDate:     time.Now().Add(-time.Hour),
+		EndDate:       time.Now().Add(time.Hour),
+		Status:        true,
+	}
+	if err := db.Create(&promo).Error; err != nil {
+		t.Fatalf("create promo failed: %v", err)
+	}
+	if err := db.Create(&entity.Promotion_Game{PromotionID: promo.ID, GameID: game.ID}).Error; err != nil {
+		t.Fatalf("link promo failed: %v", err)
+	}
+
+	unitPrice, lineDiscount, lineTotal, err := calculateLineTotal(game.ID, 2, 0)
+	if err != nil {
+		t.Fatalf("calculateLineTotal returned error: %v", err)
+	}
+	if unitPrice != 100 {
+		t.Errorf("unitPrice expected 100 got %v", unitPrice)
+	}
+	if lineDiscount != 20 {
+		t.Errorf("lineDiscount expected 20 got %v", lineDiscount)
+	}
+	if lineTotal != 180 {
+		t.Errorf("lineTotal expected 180 got %v", lineTotal)
+	}
+}


### PR DESCRIPTION
## Summary
- extract line total and discount logic into internal `calculateLineTotal`
- reuse pricing helper in `CreateOrderItem` and `CreatePaymentWithGames`
- add unit test to ensure promotion discounts are applied correctly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c151eb31688322a1c4ace2d5c5854c