### PR TITLE
Store admin replies with notification controls

### DIFF
--- a/backend/controllers/problem_report.go
+++ b/backend/controllers/problem_report.go
@@ -253,7 +253,12 @@ func ReplyReport(c *gin.Context) {
 		return
 	}
 
-	text := strings.TrimSpace(c.PostForm("text"))
+        text := strings.TrimSpace(c.PostForm("text"))
+
+        // ✅ บันทึกข้อความตอบกลับลงใน report
+        if text != "" {
+                rp.Reply = text
+        }
 
 	// ✅ แนบไฟล์ถ้ามี
 	if form, _ := c.MultipartForm(); form != nil {
@@ -278,12 +283,12 @@ func ReplyReport(c *gin.Context) {
 		}
 	}
 
-	// ✅ ยิง Notification ให้เจ้าของ report
-	if text != "" {
-		_ = db.Create(&entity.Notification{
-			Title:   fmt.Sprintf("ตอบกลับคำร้อง #%d", rp.ID),
-			Message: text,
-			Type:    "report_reply",
+        // ✅ ยิง Notification ให้เจ้าของ report
+        if text != "" {
+                _ = db.Create(&entity.Notification{
+                        Title:   fmt.Sprintf("ตอบกลับคำร้อง #%d", rp.ID),
+                        Message: text,
+                        Type:    "report_reply",
 			UserID:  rp.UserID,
 			IsRead:  false,
 		}).Error

--- a/backend/entity/problem_report.go
+++ b/backend/entity/problem_report.go
@@ -6,18 +6,21 @@ import (
 )
 
 type ProblemReport struct {
-	gorm.Model
-	Title       string `json:"title"`
-	Description string `json:"description"`
+        gorm.Model
+        Title       string `json:"title"`
+        Description string `json:"description"`
 
 	UserID uint  `json:"user_id"`
 	User   *User `gorm:"foreignKey:UserID" json:"user"`
 
-	GameID uint  `json:"game_id"`
-	Game   *Game `gorm:"foreignKey:GameID" json:"game"`
+        GameID uint  `json:"game_id"`
+        Game   *Game `gorm:"foreignKey:GameID" json:"game"`
 
-	Status     string    `json:"status" gorm:"default:open"`
-	ResolvedAt time.Time `json:"resolved_at"` // ✅ เพิ่มฟิลด์นี้
+        Status     string    `json:"status" gorm:"default:open"`
+        ResolvedAt time.Time `json:"resolved_at"` // ✅ เพิ่มฟิลด์นี้
 
-	Attachments []ProblemAttachment `json:"attachments" gorm:"foreignKey:ReportID"`
+        // ✅ ข้อความตอบกลับจากแอดมิน (ถ้ามี)
+        Reply string `json:"reply"`
+
+        Attachments []ProblemAttachment `json:"attachments" gorm:"foreignKey:ReportID"`
 }

--- a/frontend/src/interfaces/problem_report.ts
+++ b/frontend/src/interfaces/problem_report.ts
@@ -23,5 +23,8 @@ export interface ProblemReport {
   user?: User;
   game?: Game;
 
+  // ✅ ข้อความตอบกลับจากแอดมิน
+  reply?: string;
+
   attachments?: ProblemAttachment[];
 }

--- a/frontend/src/pages/Admin/AdminPage.tsx
+++ b/frontend/src/pages/Admin/AdminPage.tsx
@@ -296,6 +296,25 @@ export default function AdminPage({
                 </div>
               )}
 
+              {/* Admin reply message */}
+              {rep.reply && (
+                <div style={{ marginTop: 15 }}>
+                  <p style={{ ...textStyle, marginBottom: 8 }}>
+                    📨 Admin Reply:
+                  </p>
+                  <div
+                    style={{
+                      background: "#141322",
+                      padding: "10px 12px",
+                      borderRadius: 8,
+                      whiteSpace: "pre-line",
+                    }}
+                  >
+                    {rep.reply}
+                  </div>
+                </div>
+              )}
+
               {/* Reply form */}
               {rep.status !== "resolved" && (
                 <div style={{ marginTop: "20px" }}>

--- a/frontend/src/services/Notification.ts
+++ b/frontend/src/services/Notification.ts
@@ -1,6 +1,6 @@
 // src/services/Notification.ts
 import api from "../lib/api";
-import type { Notification, CreateNotificationRequest } from "../interfaces/Notification";
+import type { Notification } from "../interfaces/Notification";
 import type { User } from "../interfaces/User";
 
 // ดึงแจ้งเตือน (ผู้ใช้คนเดียว)
@@ -46,13 +46,18 @@ export async function createNotification(payload: {
 }): Promise<Notification | null> {
   try {
     console.log("🔔 Sending notification:", payload);
-    const res = await axios.post(`${API_URL}/notifications`, payload);
+    const res = await api.post("/notifications", payload);
     console.log("✅ Notification created:", res.data);
-    return res.data;
+    return res.data as Notification;
   } catch (err) {
     console.error("❌ createNotification error:", err);
     return null;
   }
+}
+
+// ทำเป็นอ่านแล้ว (เฉพาะรายการ)
+export async function markNotificationRead(id: number): Promise<void> {
+  await api.put(`/notifications/${id}/read`);
 }
 
 // ✅ ทำเป็นอ่านแล้วทั้งหมด

--- a/frontend/src/services/Report.ts
+++ b/frontend/src/services/Report.ts
@@ -26,6 +26,7 @@ export function normalizeReport(r: any): ProblemReport {
     game_id: r.game_id ?? r.GameID ?? 0,
     user: r.user ?? (r.User as User | undefined),
     game: r.game ?? (r.Game as Game | undefined),
+    reply: r.reply ?? r.Reply ?? "",
     attachments: r.attachments ?? (r.Attachments as ProblemAttachment[] | undefined),
   };
 }


### PR DESCRIPTION
## Summary
- store admin reply text in problem reports and return it via API
- show admin replies on the dashboard next to attachments
- allow users to mark individual notifications as read and simplify notification creation

## Testing
- `go build ./...`
- `npm run build` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c153dd33c48323b1e53812fec27a34