### PR TITLE
Handle FK constraints during migrations

### DIFF
--- a/backend/configs/db.go
+++ b/backend/configs/db.go
@@ -42,10 +42,15 @@ func SetupDatabase() {
 		log.Fatal("database is not connected; call ConnectionDB() first")
 	}
 
+	// ปิดการตรวจสอบ foreign key ชั่วคราวระหว่างการ migrate
+	db.Exec("PRAGMA foreign_keys = OFF")
+
 	// สร้างตารางให้ครบ
 	if err := db.AutoMigrate(
 		&entity.User{},
 		&entity.Game{},
+		&entity.Order{},
+		&entity.OrderItem{},
 		&entity.KeyGame{},
 		&entity.Thread{},
 		&entity.UserGame{},
@@ -53,8 +58,6 @@ func SetupDatabase() {
 		&entity.Reaction{},
 		&entity.Attachment{},
 		&entity.Notification{},
-		&entity.Order{},
-		&entity.OrderItem{},
 		&entity.Payment{},
 		&entity.PaymentSlip{},
 		&entity.PaymentReview{},
@@ -66,6 +69,9 @@ func SetupDatabase() {
 	); err != nil {
 		log.Fatal("auto migrate failed: ", err)
 	}
+
+	// เปิดการตรวจสอบ foreign key กลับหลังจาก migrate เสร็จ
+	db.Exec("PRAGMA foreign_keys = ON")
 
 	seedIfNeeded()
 }


### PR DESCRIPTION
## Summary
- disable SQLite foreign key checks during migrations
- migrate OrderItem before KeyGame to satisfy reference

## Testing
- `go run -v main.go`


------
https://chatgpt.com/codex/tasks/task_e_68c155379d608322a6fc0ac58a8309c1