### PR TITLE
refactor: use id from auth context

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -12,7 +12,7 @@ import type { Notification } from '../interfaces/Notification';
 const Navbar = () => {
   const [openAuth, setOpenAuth] = useState(false);
   const [notifications, setNotifications] = useState<Notification[]>([]);
-  const { token, username, logout, userId } = useAuth();
+  const { token, username, logout, id } = useAuth();
 
   const handleLoginSuccess = () => {
     setNotifications((prev) => [
@@ -22,7 +22,7 @@ const Navbar = () => {
         title: 'Login Successful',
         message: 'You have logged in successfully',
         type: 'system',
-        user_id: userId ?? 0,
+        user_id: id ?? 0,
       },
     ]);
   };

--- a/frontend/src/components/Payment.tsx
+++ b/frontend/src/components/Payment.tsx
@@ -57,7 +57,7 @@ const PaymentPage = () => {
   const [files, setFiles] = useState<UploadFile[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const navigate = useNavigate();
-  const { id: userId } = useAuth();
+  const { id } = useAuth();
 
   const updateItems = (next: CartItem[]) => {
     setItems(next);
@@ -110,7 +110,7 @@ const PaymentPage = () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          user_id: userId || 1,
+          user_id: id || 1,
           games: items.map((it) => ({
             game_id: it.id,
             quantity: it.quantity,

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import { Button, Space, Typography } from "antd";
 const { Title } = Typography;
 
 const Home = () => {
-  const { userId } = useAuth();
+  const { id } = useAuth();
   return (
     <div style={{ background: '#141414', flex: 1 , minHeight: '100vh'}}>
       <Navbar />
@@ -19,7 +19,7 @@ const Home = () => {
           <Button shape="round">Recommended</Button>
           <Button shape="round">Filter</Button>
         </Space>
-        <ProductGrid userId={userId} />
+        <ProductGrid userId={id} />
       </div>
     </div>
   );

--- a/frontend/src/pages/Promotion/PromotionManager.tsx
+++ b/frontend/src/pages/Promotion/PromotionManager.tsx
@@ -37,7 +37,7 @@ export default function PromotionManager() {
   const [games, setGames] = useState<GameLite[]>([]);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [promoFile, setPromoFile] = useState<File | null>(null);
-  const { userId: currentUserId, token } = useAuth();
+  const { id, token } = useAuth();
   const isEdit = useMemo(() => editingId !== null, [editingId]);
   const discountType = Form.useWatch("discount_type", form);
 
@@ -94,8 +94,8 @@ export default function PromotionManager() {
       body.append("end_date", values.dateRange[1].toISOString());
       body.append("status", String(values.status));
       values.gameIds.forEach(id => body.append("game_ids", id));
-      if (currentUserId != null) {
-        body.append("user_id", String(currentUserId));
+      if (id != null) {
+        body.append("user_id", String(id));
       }
       if (promoFile) {
         body.append("promo_image", promoFile);

--- a/frontend/src/pages/Review/Mygame.tsx
+++ b/frontend/src/pages/Review/Mygame.tsx
@@ -7,7 +7,7 @@ const { Content } = Layout;
 const { Title } = Typography;
 
 const Mygame = () => {
-  const { userId } = useAuth();
+  const { id } = useAuth();
   return (
     <Layout style={{ minHeight: "100vh", background: "#0f0f0f" }}>
       {/* Sidebar ทางซ้าย */}
@@ -33,7 +33,7 @@ const Mygame = () => {
           </Space>
 
           {/* UI-only: แสดงกริดเกมจากคอมโพเนนต์ที่มีอยู่แล้ว */}
-          <ProductGrid userId={userId} />
+          <ProductGrid userId={id} />
         </div>
       </Content>
     </Layout>


### PR DESCRIPTION
## Summary
- use `id` from auth context across navbar, home, and reviews
- pass auth `id` to promotion manager and payment components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 36 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c1593cc47c8322afcc731e93daaa90