### PR TITLE
Check auth before submitting payment slip

### DIFF
--- a/frontend/src/components/Payment.tsx
+++ b/frontend/src/components/Payment.tsx
@@ -103,6 +103,10 @@ const PaymentPage = () => {
       message.error("ไม่มีรายการสินค้า");
       return;
     }
+    if (!id) {
+      message.error("กรุณาเข้าสู่ระบบก่อนทำรายการ");
+      return;
+    }
     try {
       setSubmitting(true);
       // 1) สร้างออร์เดอร์และการชำระเงินจากรายการสินค้า
@@ -110,7 +114,7 @@ const PaymentPage = () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          user_id: id || 1,
+          user_id: id,
           games: items.map((it) => ({
             game_id: it.id,
             quantity: it.quantity,


### PR DESCRIPTION
## Summary
- ensure users are logged in before submitting payment slip
- pass user_id from auth without defaulting

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 37 errors, unrelated to changes)


------
https://chatgpt.com/codex/tasks/task_e_68c15a635c1c8322ab687ea2eee31e11