### PR TITLE
feat: load reviews for game route

### DIFF
--- a/backend/controllers/reviews.go
+++ b/backend/controllers/reviews.go
@@ -168,7 +168,8 @@ func ToggleReviewLike(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"review_id": review.ID, "likes": count})
 }
 
-// GET /games/:id/reviews
+// FindReviewsByGame handles GET /games/:id/reviews
+// and returns all reviews for a particular game.
 func FindReviewsByGame(c *gin.Context) {
 	var rows []entity.Review
 	if err := configs.DB().

--- a/frontend/src/components/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection.tsx
@@ -32,6 +32,7 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({ gameId, allowCreate = tru
   async function load() {
     setLoading(true);
     try {
+      // Load reviews for the given game via GET /games/:gameId/reviews
       const list = await ReviewsAPI.listByGame(gameId);
       setItems(
         list

--- a/frontend/src/pages/Review/Reviewpage.tsx
+++ b/frontend/src/pages/Review/Reviewpage.tsx
@@ -1,4 +1,4 @@
-// frontend/src/pages/Review/DevReviewsStandalone.tsx
+// frontend/src/pages/Review/Reviewpage.tsx
 import React, { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
@@ -31,7 +31,8 @@ function resolveImgUrl(img?: string) {
   return `${BASE}/${s.replace(/^\/+/, "")}`;
 }
 
-const DevReviewsStandalone: React.FC = () => {
+// Reviewpage fetches a game by id from the URL and renders its reviews.
+const Reviewpage: React.FC = () => {
   const { gameId } = useParams();
   const [loading, setLoading] = useState(true);
   const [game, setGame] = useState<{ id: number; name: string; img?: string } | null>(null);
@@ -97,4 +98,4 @@ const DevReviewsStandalone: React.FC = () => {
   );
 };
 
-export default DevReviewsStandalone;
+export default Reviewpage;

--- a/frontend/src/routes/text.tsx
+++ b/frontend/src/routes/text.tsx
@@ -81,6 +81,7 @@ const router = createBrowserRouter([
 
       { path: "/promotion", element: <PromotionManager /> },
       { path: "/promotion/:id", element: <PromotionDetail /> },
+      // Review page for a specific game
       { path: "/reviews/:gameId", element: <Reviewpage /> },
 
 


### PR DESCRIPTION
## Summary
- align review page component with routing and fetch game info by id
- document review section loading reviews via game-specific endpoint
- add route and backend controller comments for per-game reviews

## Testing
- `go test ./...`
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: lint errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68c15a5c6480832989048318c67893d8