### PR TITLE
Filter games based on user orders

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -19,7 +19,7 @@ const Home = () => {
           <Button shape="round">Recommended</Button>
           <Button shape="round">Filter</Button>
         </Space>
-        <ProductGrid userId={id} />
+        <ProductGrid id={id} />
       </div>
     </div>
   );

--- a/frontend/src/pages/Review/Mygame.tsx
+++ b/frontend/src/pages/Review/Mygame.tsx
@@ -33,7 +33,7 @@ const Mygame = () => {
           </Space>
 
           {/* UI-only: แสดงกริดเกมจากคอมโพเนนต์ที่มีอยู่แล้ว */}
-          <ProductGrid userId={id} />
+          <ProductGrid id={id} />
         </div>
       </Content>
     </Layout>


### PR DESCRIPTION
## Summary
- Filter games by user ownership by fetching `/orders` with auth token
- Adjust ProductGrid to accept `id` prop and use it to show owned games
- Update Home and Mygame pages to pass the new `id` prop

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: eslint found 37 errors, 2 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c15c0b6d80832296255772653039be