### PR TITLE
fix: show games on home page after login

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,12 +1,10 @@
 import Navbar from "../components/Navbar";
 import ProductGrid from "../components/ProductGrid";
-import { useAuth } from "../context/AuthContext";
 import { Button, Space, Typography } from "antd";
 
 const { Title } = Typography;
 
 const Home = () => {
-  const { id } = useAuth();
   return (
     <div style={{ background: '#141414', flex: 1 , minHeight: '100vh'}}>
       <Navbar />
@@ -19,7 +17,7 @@ const Home = () => {
           <Button shape="round">Recommended</Button>
           <Button shape="round">Filter</Button>
         </Space>
-        <ProductGrid id={id} />
+        <ProductGrid />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- display all games on home page for logged-in users

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68c15f2e64588322897fa187293f686b