### PR TITLE
Implement JWT-based permission checks

### DIFF
--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -1,0 +1,90 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// AuthMiddleware verifies JWT token and loads current user
+func AuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := c.GetHeader("Authorization")
+		if auth == "" || !strings.HasPrefix(auth, "Bearer ") {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authorization header missing"})
+			return
+		}
+		tokenString := strings.TrimPrefix(auth, "Bearer ")
+
+		secret := os.Getenv("JWT_SECRET")
+		if secret == "" {
+			secret = "secret"
+		}
+
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, jwt.ErrInvalidKeyType
+			}
+			return []byte(secret), nil
+		})
+		if err != nil || !token.Valid {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+			return
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token claims"})
+			return
+		}
+		sub, ok := claims["sub"].(float64)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token subject"})
+			return
+		}
+
+		var user entity.User
+		if err := configs.DB().Preload("Role.RolePermissions.Permission").First(&user, uint(sub)).Error; err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "user not found"})
+			return
+		}
+
+		c.Set("currentUser", &user)
+		c.Next()
+	}
+}
+
+// RequirePermission checks that current user has one of the required permission keys
+func RequirePermission(keys ...string) gin.HandlerFunc {
+	required := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		required[k] = struct{}{}
+	}
+
+	return func(c *gin.Context) {
+		v, exists := c.Get("currentUser")
+		if !exists {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		user, ok := v.(*entity.User)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+
+		for _, rp := range user.Role.RolePermissions {
+			if _, ok := required[rp.Permission.Key]; ok {
+				c.Next()
+				return
+			}
+		}
+
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "you do not have permission to access this resource"})
+	}
+}


### PR DESCRIPTION
## Summary
- add JWT auth middleware and permission enforcement
- include user role and permissions in login response
- secure API routes with role-based authorization

## Testing
- `go test ./...` *(hangs, terminated)*
- `go vet ./...` *(hangs, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c20faac4f0832ab2f9965829ab0d68