### PR TITLE
fix: add unknown status fallback

### DIFF
--- a/frontend/src/pages/Admin/AdminPaymentReviewPage.tsx
+++ b/frontend/src/pages/Admin/AdminPaymentReviewPage.tsx
@@ -197,15 +197,17 @@ export default function AdminPaymentReviewPage() {
             {
               title: "สถานะ",
               dataIndex: "status",
-              render: (s: PaymentStatus, r) =>
+              render: (s: PaymentStatus | string | undefined, r) =>
                 s === "PENDING" ? (
                   <Tag color="gold">รอตรวจสอบ</Tag>
                 ) : s === "APPROVED" ? (
                   <Tag color="success">อนุมัติแล้ว</Tag>
-                ) : (
+                ) : s === "REJECTED" ? (
                   <Tooltip title={r.reject_reason}>
                     <Tag color="error">ปฏิเสธแล้ว</Tag>
                   </Tooltip>
+                ) : (
+                  <Tag color="default">ไม่ทราบ</Tag>
                 ),
             },
             {


### PR DESCRIPTION
## Summary
- handle unrecognized payment statuses by showing a neutral tag instead of rejection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 73 errors, 5 warnings)*
- `npm run build` *(fails: TypeScript errors in unrelated files)*
- `node -e "const renderStatus=s=>s==='PENDING'? 'รอตรวจสอบ': s==='APPROVED'? 'อนุมัติแล้ว': s==='REJECTED'? 'ปฏิเสธแล้ว':'ไม่ทราบ'; console.log(renderStatus()); console.log(renderStatus('PENDING'));"`


------
https://chatgpt.com/codex/tasks/task_e_68c219116bc883228e73b6e9728efed1