### PR TITLE
Implement default user permissions and permission-aware routes

### DIFF
--- a/backend/configs/db.go
+++ b/backend/configs/db.go
@@ -320,6 +320,28 @@ func seedPermissionsAndGrantAdmin(adminID uint) {
 	}
 }
 
+// มอบสิทธิพื้นฐานให้กับ role User
+func grantBasicUserPermissions(userRoleID uint) {
+	keys := []string{
+		"games.read",
+		"workshop.read",
+		"community.read",
+		"promotions.read",
+		"reviews.read",
+	}
+
+	for _, k := range keys {
+		p, err := ensurePermission(k, "", "")
+		if err != nil {
+			log.Println("ensure permission for user error:", k, err)
+			continue
+		}
+		if err := ensureRoleHasPermission(userRoleID, p.ID); err != nil {
+			log.Println("grant user perm error:", k, err)
+		}
+	}
+}
+
 // ---------- Setup / Seed ----------
 
 // AutoMigrate และ seed ข้อมูลตัวอย่าง (ถ้ายังว่าง) — ไม่ต้องดรอปตาราง
@@ -351,8 +373,9 @@ func SetupDatabase() {
 	adminRoleID = roleAdmin.ID
 	userRoleID = roleUser.ID
 
-	// Seed permissions & มอบให้ admin
+	// Seed permissions & มอบให้ admin และ user
 	seedPermissionsAndGrantAdmin(roleAdmin.ID)
+	grantBasicUserPermissions(roleUser.ID)
 
 	// เฟส 3: ซ่อม users.role_id ให้ชี้ role ที่มีจริง (กันพังตอนคัดลอกเข้า users__temp ระหว่าง migrate)
 	if tableExists("users") {

--- a/backend/main.go
+++ b/backend/main.go
@@ -63,8 +63,8 @@ func main() {
 		auth.DELETE("/rolepermissions/:id", middleware.RequirePermission("roles.manage"), controllers.DeleteRolePermission)
 
 		// ===== Games =====
-		auth.POST("/new-game", middleware.RequirePermission("games.manage"), controllers.CreateGame)
 		auth.GET("/game", middleware.RequirePermission("games.read"), controllers.FindGames)
+		auth.POST("/new-game", middleware.RequirePermission("games.manage"), controllers.CreateGame)
 		auth.PUT("/update-game/:id", middleware.RequirePermission("games.manage"), controllers.UpdateGamebyID)
 		auth.POST("/upload/game", middleware.RequirePermission("games.manage"), controllers.UploadGame)
 

--- a/frontend/src/components/AuthModal.tsx
+++ b/frontend/src/components/AuthModal.tsx
@@ -38,7 +38,13 @@ const AuthModal: React.FC<AuthModalProps> = ({ open, onClose, onLoginSuccess }) 
         return;
       }
 
-      login(result.id, result.token, result.username ?? values.username);
+      login(
+        result.id,
+        result.token,
+        result.username ?? values.username,
+        result.role,
+        result.permissions ?? [],
+      );
       const notification = {
         ID: Date.now(),
         title: 'ระบบ',
@@ -101,7 +107,13 @@ const AuthModal: React.FC<AuthModalProps> = ({ open, onClose, onLoginSuccess }) 
         return;
       }
 
-      login(loginData.id, loginData.token, loginData.username ?? values.username);
+      login(
+        loginData.id,
+        loginData.token,
+        loginData.username ?? values.username,
+        loginData.role,
+        loginData.permissions ?? [],
+      );
       onClose();
     } catch (error) {
       console.error(error);

--- a/frontend/src/components/RequirePermission.tsx
+++ b/frontend/src/components/RequirePermission.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useAuth } from '../context/AuthContext';
+
+interface Props {
+  anyOf: string[];
+  children: React.ReactElement;
+}
+
+const RequirePermission: React.FC<Props> = ({ anyOf, children }) => {
+  const { permissions } = useAuth();
+  const allowed = anyOf.some((p) => permissions.includes(p));
+  if (!allowed) {
+    return <div style={{ padding: 24 }}>คุณไม่สามารถเข้าถึงหน้านี้ได้ เนื่องจากไม่มีสิทธิ์</div>;
+  }
+  return children;
+};
+
+export default RequirePermission;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -5,45 +5,78 @@ interface AuthContextType {
   id: number | null;
   token: string | null;
   username: string | null;
-  login: (id:number, token: string, username: string) => void;
+  role: string | null;
+  permissions: string[];
+  login: (
+    id: number,
+    token: string,
+    username: string,
+    role: string,
+    permissions: string[],
+  ) => void;
   logout: () => void;
+  hasPermission: (key: string) => boolean;
 }
 
 const AuthContext = createContext<AuthContextType>({
   id: null,
   token: null,
   username: null,
+  role: null,
+  permissions: [],
   login: () => {},
   logout: () => {},
+  hasPermission: () => false,
 });
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
   const [username, setUsername] = useState<string | null>(localStorage.getItem('username'));
+  const [role, setRole] = useState<string | null>(localStorage.getItem('role'));
+  const [permissions, setPermissions] = useState<string[]>(() => {
+    const s = localStorage.getItem('permissions');
+    try { return s ? JSON.parse(s) : []; } catch { return []; }
+  });
   const [id, setId] = useState<number | null>(() => {
     const s = localStorage.getItem("userid");
     return s ? Number(s) : null;
   });
-  const login = (newId: number, newToken: string, name: string) => {
+  const login = (
+    newId: number,
+    newToken: string,
+    name: string,
+    newRole: string,
+    perms: string[],
+  ) => {
     setId(newId);
     setToken(newToken);
     setUsername(name);
+    setRole(newRole);
+    setPermissions(perms);
     localStorage.setItem('token', newToken);
     localStorage.setItem('username', name);
     localStorage.setItem('userid', String(newId));
+    localStorage.setItem('role', newRole);
+    localStorage.setItem('permissions', JSON.stringify(perms));
   };
 
   const logout = () => {
     setId(null);
     setToken(null);
     setUsername(null);
+    setRole(null);
+    setPermissions([]);
     localStorage.removeItem('token');
     localStorage.removeItem('username');
     localStorage.removeItem('userid');
+    localStorage.removeItem('role');
+    localStorage.removeItem('permissions');
   };
 
+  const hasPermission = (key: string) => permissions.includes(key);
+
   return (
-    <AuthContext.Provider value={{ id, token, username, login, logout }}>
+    <AuthContext.Provider value={{ id, token, username, role, permissions, login, logout, hasPermission }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/routes/text.tsx
+++ b/frontend/src/routes/text.tsx
@@ -21,6 +21,7 @@ import AdminPaymentReviewPage from "../pages/Admin/AdminPaymentReviewPage.tsx";
 import PromotionManager from "../pages/Promotion/PromotionManager.tsx";
 import RoleEdit from "../pages/role/RoleEdit.tsx";
 import PromotionDetail from "../pages/Promotion/PromotionDetail.tsx";
+import RequirePermission from "../components/RequirePermission.tsx";
 // 🟣 Mock Refund Data
 const refunds: Refund[] = [
   {
@@ -102,16 +103,31 @@ const router = createBrowserRouter([
             ),
           },
           { path: "/Admin/PaymentReviewPage", element: <AdminPaymentReviewPage /> },
-          { path: "/Admin/RolePage", element: <RoleManagement /> },
+          {
+            path: "/Admin/RolePage",
+            element: (
+              <RequirePermission anyOf={["roles.manage"]}>
+                <RoleManagement />
+              </RequirePermission>
+            ),
+          },
         ],
       },
       {
         path: "/roles",
-        element: <RoleManagement />
+        element: (
+          <RequirePermission anyOf={["roles.read", "roles.manage"]}>
+            <RoleManagement />
+          </RequirePermission>
+        ),
       },
       {
         path: "/roles/:id",
-        element: <RoleEdit />
+        element: (
+          <RequirePermission anyOf={["roles.manage"]}>
+            <RoleEdit />
+          </RequirePermission>
+        ),
       }
     ],
   },


### PR DESCRIPTION
## Summary
- seed basic read permissions for User role and protect game listing
- store role/permissions in auth context and gate role pages with `RequirePermission`

## Testing
- `go build ./...`
- `npm --prefix frontend run build` *(fails: TS errors in existing pages)*
- `curl -s -X POST http://localhost:8088/login` and `curl -i http://localhost:8088/roles`


------
https://chatgpt.com/codex/tasks/task_e_68c22003cf7c832a983ac930495b41ff