### PR TITLE
refactor: use snake_case for review API

### DIFF
--- a/frontend/src/components/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection.tsx
@@ -80,13 +80,14 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({ gameId, allowCreate = tru
       const values = await form.validateFields();
 
       if (editing) {
-        // PUT: ต้องใช้ฟิลด์ ReviewTitle/ReviewText/Rating ให้ตรง backend
         const saved = await ReviewsAPI.updateJson(
           editing.ID,
           {
-            ReviewTitle: values.title,
-            ReviewText: values.content,
-            Rating: values.rating,
+            game_id: editing.game_id,
+            user_id: editing.user_id,
+            review_title: values.title,
+            review_text: values.content,
+            rating: values.rating,
           },
           token || undefined
         );
@@ -97,14 +98,13 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({ gameId, allowCreate = tru
           message.info("กรุณาเข้าสู่ระบบ");
           return;
         }
-        // POST: ส่ง GameID/UserID/ReviewTitle/ReviewText/Rating
         const created = await ReviewsAPI.createJson(
           {
-            GameID: gameId,
-            UserID: userId,
-            ReviewTitle: values.title,
-            ReviewText: values.content,
-            Rating: values.rating,
+            game_id: gameId,
+            user_id: userId,
+            review_title: values.title,
+            review_text: values.content,
+            rating: values.rating,
           },
           token || undefined
         );

--- a/frontend/src/services/reviews.ts
+++ b/frontend/src/services/reviews.ts
@@ -29,12 +29,12 @@ export const normalizeReview = (r: any): ReviewItem => ({
   UpdatedAt: r?.UpdatedAt ?? r?.updatedAt ?? r?.updated_at ?? "",
   DeletedAt: r?.DeletedAt ?? r?.deletedAt ?? r?.deleted_at ?? null,
 
-  title: r?.ReviewTitle ?? r?.title ?? "",
-  content: r?.ReviewText ?? r?.content ?? "",
-  rating: Number(r?.Rating ?? r?.rating ?? 0),
+  title: r?.review_title ?? r?.ReviewTitle ?? r?.title ?? "",
+  content: r?.review_text ?? r?.ReviewText ?? r?.content ?? "",
+  rating: Number(r?.rating ?? r?.Rating ?? 0),
 
-  game_id: Number(r?.GameID ?? r?.game_id ?? r?.gameId),
-  user_id: Number(r?.UserID ?? r?.user_id ?? r?.userId),
+  game_id: Number(r?.game_id ?? r?.GameID ?? r?.gameId),
+  user_id: Number(r?.user_id ?? r?.UserID ?? r?.userId),
 
   username: r?.username,
   likes: typeof r?.likes === "number" ? r.likes : 0,
@@ -51,14 +51,14 @@ export const ReviewsAPI = {
     return arr.map(normalizeReview);
   },
 
-  /** POST /reviews  — ต้องส่งชื่อฟิลด์ให้ตรง backend */
+  /** POST /reviews */
   async createJson(
     payload: {
-      GameID: number;
-      UserID: number;
-      ReviewTitle?: string;
-      ReviewText: string;
-      Rating: number;
+      game_id: number;
+      user_id: number;
+      review_title?: string;
+      review_text: string;
+      rating: number;
     },
     token?: string
   ): Promise<ReviewItem> {
@@ -75,9 +75,11 @@ export const ReviewsAPI = {
   async updateJson(
     id: number,
     payload: {
-      ReviewTitle?: string;
-      ReviewText: string;
-      Rating: number;
+      game_id: number;
+      user_id: number;
+      review_title?: string;
+      review_text: string;
+      rating: number;
     },
     token?: string
   ): Promise<ReviewItem> {


### PR DESCRIPTION
## Summary
- send snake_case fields when creating or updating reviews
- adjust review service to accept and normalize snake_case payloads

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, and other lint errors)*
- `curl -s -X POST http://localhost:8088/reviews -H 'Content-Type: application/json' -d '{"game_id":1,"user_id":1,"review_title":"Great","review_text":"Fun game","rating":9}'`
- `curl -s -X PUT http://localhost:8088/reviews/6 -H 'Content-Type: application/json' -d '{"game_id":1,"user_id":1,"review_title":"Updated","review_text":"Really fun","rating":10}'`
- `curl -s -X POST http://localhost:8088/reviews/6/toggle_like -H 'Content-Type: application/json' -d '{"user_id":2}'`


------
https://chatgpt.com/codex/tasks/task_e_68c24bf3931c8329a2919f873e1a7208