### PR TITLE
feat: add user info endpoint and refresh permissions

### DIFF
--- a/backend/controllers/me.go
+++ b/backend/controllers/me.go
@@ -1,0 +1,36 @@
+package controllers
+
+import (
+	"net/http"
+
+	"example.com/sa-gameshop/entity"
+	"github.com/gin-gonic/gin"
+)
+
+// Me returns current user info and permissions
+func Me(c *gin.Context) {
+	u, ok := c.Get("user")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not found"})
+		return
+	}
+	user := u.(entity.User)
+
+	perms := []string{}
+	for _, rp := range user.Role.RolePermissions {
+		if rp.Permission != nil {
+			perms = append(perms, rp.Permission.Key)
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"id":       user.ID,
+		"username": user.Username,
+		"email":    user.Email,
+		"role": gin.H{
+			"id":    user.RoleID,
+			"title": user.Role.Title,
+		},
+		"permissions": perms,
+	})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -26,6 +26,7 @@ func main() {
 	router := r.Group("/")
 	{
 		router.POST("/login", controllers.Login)
+		router.GET("/me", middlewares.Authorize(""), controllers.Me)
 		// ===== Users =====
 		router.POST("/users", controllers.CreateUser)
 		router.GET("/users", middlewares.Authorize("users.manage"), controllers.FindUsers)
@@ -79,32 +80,32 @@ func main() {
 		router.DELETE("/comments/:id", middlewares.Authorize("community.moderate"), controllers.DeleteCommentByID)
 
 		// ===== UserGames (สิทธิ์การเป็นเจ้าของเกม) =====
-		router.POST("/user-games", controllers.CreateUserGame)
-		router.GET("/user-games", controllers.FindUserGames)
-		router.GET("/user-games/:id", controllers.FindUserGameByID)
-		router.PUT("/user-games/:id", controllers.UpdateUserGame)
-		router.DELETE("/user-games/:id", controllers.DeleteUserGameByID)
+		router.POST("/user-games", middlewares.Authorize("games.manage"), controllers.CreateUserGame)
+		router.GET("/user-games", middlewares.Authorize("games.read"), controllers.FindUserGames)
+		router.GET("/user-games/:id", middlewares.Authorize("games.read"), controllers.FindUserGameByID)
+		router.PUT("/user-games/:id", middlewares.Authorize("games.manage"), controllers.UpdateUserGame)
+		router.DELETE("/user-games/:id", middlewares.Authorize("games.manage"), controllers.DeleteUserGameByID)
 
 		// ===== Reactions =====
-		router.POST("/reactions", controllers.CreateReaction)
-		router.GET("/reactions", controllers.FindReactions) // ใช้ ?target_type=&target_id=&user_id=
-		router.GET("/reactions/:id", controllers.FindReactionByID)
-		router.PUT("/reactions/:id", controllers.UpdateReaction)
-		router.DELETE("/reactions/:id", controllers.DeleteReactionByID)
+		router.POST("/reactions", middlewares.Authorize("community.read"), controllers.CreateReaction)
+		router.GET("/reactions", middlewares.Authorize("community.read"), controllers.FindReactions) // ใช้ ?target_type=&target_id=&user_id=
+		router.GET("/reactions/:id", middlewares.Authorize("community.read"), controllers.FindReactionByID)
+		router.PUT("/reactions/:id", middlewares.Authorize("community.moderate"), controllers.UpdateReaction)
+		router.DELETE("/reactions/:id", middlewares.Authorize("community.moderate"), controllers.DeleteReactionByID)
 
 		// ===== Attachments =====
-		router.POST("/attachments", controllers.CreateAttachment)
-		router.GET("/attachments", controllers.FindAttachments) // ใช้ ?target_type=&target_id=&user_id=
-		router.GET("/attachments/:id", controllers.FindAttachmentByID)
-		router.PUT("/attachments/:id", controllers.UpdateAttachment)
-		router.DELETE("/attachments/:id", controllers.DeleteAttachmentByID)
+		router.POST("/attachments", middlewares.Authorize("community.read"), controllers.CreateAttachment)
+		router.GET("/attachments", middlewares.Authorize("community.read"), controllers.FindAttachments) // ใช้ ?target_type=&target_id=&user_id=
+		router.GET("/attachments/:id", middlewares.Authorize("community.read"), controllers.FindAttachmentByID)
+		router.PUT("/attachments/:id", middlewares.Authorize("community.moderate"), controllers.UpdateAttachment)
+		router.DELETE("/attachments/:id", middlewares.Authorize("community.moderate"), controllers.DeleteAttachmentByID)
 
 		// ===== Notifications =====
-		router.POST("/notifications", controllers.CreateNotification)
-		router.GET("/notifications", controllers.FindNotifications) // ใช้ ?user_id=
-		router.GET("/notifications/:id", controllers.FindNotificationByID)
-		router.PUT("/notifications/:id", controllers.UpdateNotification)
-		router.DELETE("/notifications/:id", controllers.DeleteNotificationByID)
+		router.POST("/notifications", middlewares.Authorize("community.read"), controllers.CreateNotification)
+		router.GET("/notifications", middlewares.Authorize("community.read"), controllers.FindNotifications) // ใช้ ?user_id=
+		router.GET("/notifications/:id", middlewares.Authorize("community.read"), controllers.FindNotificationByID)
+		router.PUT("/notifications/:id", middlewares.Authorize("community.moderate"), controllers.UpdateNotification)
+		router.DELETE("/notifications/:id", middlewares.Authorize("community.moderate"), controllers.DeleteNotificationByID)
 
 		// ===== Promotions
 		router.POST("/promotions", middlewares.Authorize("promotions.manage"), controllers.CreatePromotion)
@@ -116,24 +117,24 @@ func main() {
 		router.GET("/promotions-active", middlewares.Authorize("promotions.read"), controllers.FindActivePromotions)
 
 		// ===== Reviews
-		router.POST("/reviews", controllers.CreateReview)
-		router.GET("/reviews", controllers.FindReviews) // ?game_id=&user_id=
-		router.GET("/reviews/:id", controllers.GetReviewByID)
-		router.PUT("/reviews/:id", controllers.UpdateReview)
-		router.DELETE("/reviews/:id", controllers.DeleteReview)
-		router.POST("/reviews/:id/toggle_like", controllers.ToggleReviewLike)
-		router.GET("/games/:id/reviews", controllers.FindReviewsByGame)
+		router.POST("/reviews", middlewares.Authorize("reviews.read"), controllers.CreateReview)
+		router.GET("/reviews", middlewares.Authorize("reviews.read"), controllers.FindReviews) // ?game_id=&user_id=
+		router.GET("/reviews/:id", middlewares.Authorize("reviews.read"), controllers.GetReviewByID)
+		router.PUT("/reviews/:id", middlewares.Authorize("reviews.moderate"), controllers.UpdateReview)
+		router.DELETE("/reviews/:id", middlewares.Authorize("reviews.moderate"), controllers.DeleteReview)
+		router.POST("/reviews/:id/toggle_like", middlewares.Authorize("reviews.read"), controllers.ToggleReviewLike)
+		router.GET("/games/:id/reviews", middlewares.Authorize("reviews.read"), controllers.FindReviewsByGame)
 
 		// categories routes
-		router.GET("/categories", controllers.FindCategories)
+		router.GET("/categories", middlewares.Authorize("games.read"), controllers.FindCategories)
 
 		// keygame routes
-		router.GET("/keygame", controllers.FindKeyGame)
-		router.POST("/new-keygame", controllers.CreateKeyGame)
+		router.GET("/keygame", middlewares.Authorize("games.read"), controllers.FindKeyGame)
+		router.POST("/new-keygame", middlewares.Authorize("games.manage"), controllers.CreateKeyGame)
 
 		//minimumspec routes
-		router.POST("/new-minimumspec", controllers.CreateMinimumSpec)
-		router.GET("/minimumspec", controllers.FindMinimumSpec)
+		router.POST("/new-minimumspec", middlewares.Authorize("games.manage"), controllers.CreateMinimumSpec)
+		router.GET("/minimumspec", middlewares.Authorize("games.read"), controllers.FindMinimumSpec)
 
 		//request routes
 		router.POST("/new-request", middlewares.Authorize("requests.create"), controllers.CreateRequest)
@@ -167,18 +168,18 @@ func main() {
 		router.DELETE("/mods/:id", middlewares.Authorize("workshop.moderate"), controllers.DeleteMod)
 
 		// ===== Mod Ratings =====
-		router.GET("/modratings", controllers.GetModRatings)
-		router.GET("/modratings/:id", controllers.GetModRatingById)
-		router.POST("/modratings", controllers.CreateModRating)
-		router.PATCH("/modratings/:id", controllers.UpdateModRating)
-		router.DELETE("/modratings/:id", controllers.DeleteModRating)
+		router.GET("/modratings", middlewares.Authorize("workshop.read"), controllers.GetModRatings)
+		router.GET("/modratings/:id", middlewares.Authorize("workshop.read"), controllers.GetModRatingById)
+		router.POST("/modratings", middlewares.Authorize("workshop.read"), controllers.CreateModRating)
+		router.PATCH("/modratings/:id", middlewares.Authorize("workshop.moderate"), controllers.UpdateModRating)
+		router.DELETE("/modratings/:id", middlewares.Authorize("workshop.moderate"), controllers.DeleteModRating)
 
 		// ===== Mod Tags =====
-		router.GET("/modtags", controllers.GetModTags)
-		router.GET("/modtags/:id", controllers.GetModTagById)
-		router.POST("/modtags", controllers.CreateModTag)
-		router.PATCH("/modtags/:id", controllers.UpdateModTag)
-		router.DELETE("/modtags/:id", controllers.DeleteModTag)
+		router.GET("/modtags", middlewares.Authorize("workshop.read"), controllers.GetModTags)
+		router.GET("/modtags/:id", middlewares.Authorize("workshop.read"), controllers.GetModTagById)
+		router.POST("/modtags", middlewares.Authorize("workshop.moderate"), controllers.CreateModTag)
+		router.PATCH("/modtags/:id", middlewares.Authorize("workshop.moderate"), controllers.UpdateModTag)
+		router.DELETE("/modtags/:id", middlewares.Authorize("workshop.moderate"), controllers.DeleteModTag)
 
 	}
 
@@ -190,7 +191,7 @@ func main() {
 // CORS แบบเดียวกับตัวอย่างที่แนบมา
 func CORSMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		c.Writer.Header().Set("Access-Control-Allow-Origin", "http://localhost:5173")
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE, PATCH")

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -4,26 +4,27 @@ import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import { PlusOutlined } from "@ant-design/icons";
 import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "../context/AuthContext";
+import type { ReactNode } from "react";
 
 const { Sider } = Layout;
 type GroupItem = Required<MenuProps>["items"][number];
 
-const items: GroupItem[] = [
-  {
-    key: "/home",
-    label: "หน้าแรก",
-  },
-  {
-    key: "/request",
-    label: "รีเควสเกม",
-  },
-  {
-    key: "/requestinfo",
-    label: "ข้อมูลรีเควส",
-  },
+type MenuItem = {
+  key: string;
+  label: string;
+  need?: string;
+  icon?: ReactNode;
+  children?: MenuItem[];
+};
+
+const menuItems: MenuItem[] = [
+  { key: "/home", label: "หน้าแรก", need: "games.read" },
+  { key: "/request", label: "รีเควสเกม", need: "requests.create" },
+  { key: "/requestinfo", label: "ข้อมูลรีเควส", need: "requests.read" },
   {
     key: "/information",
     label: "จัดการข้อมูลเกม",
+    need: "games.manage",
     children: [
       { key: "/information/Add", label: "เพิ่มเกม", icon: <PlusOutlined /> },
       { key: "/information/Edit", label: "แก้ไขข้อมูลเกม", icon: <PlusOutlined /> },
@@ -33,30 +34,21 @@ const items: GroupItem[] = [
     key: "/category",
     label: "หมวดหมู่",
     children: [
-      { key: "/category/Community", label: "ชุมชน", icon: <PlusOutlined /> },
-      { key: "/category/Payment", label: "การชำระเงิน", icon: <PlusOutlined /> },
+      { key: "/category/Community", label: "ชุมชน", icon: <PlusOutlined />, need: "community.read" },
+      { key: "/category/Payment", label: "การชำระเงิน", icon: <PlusOutlined />, need: "payments.create" },
     ],
   },
-
+  { key: "/workshop", label: "Workshop", need: "workshop.read" },
+  { key: "/promotion", label: "Promotion", need: "promotions.manage" },
+  { key: "/refund", label: "การคืนเงินผู้ใช้", need: "refunds.manage" },
   {
-    key: "/workshop",
-    label: "Workshop",
-  },
-    {
-    key: '/promotion',
-    label:'Promotion',
-  },
-  {
-    key: '/refund',
-    label:'การคืนเงินผู้ใช้',
-  },
-  {
-    key: '/Admin',
-    label:'Admin',
+    key: "/Admin",
+    label: "Admin",
+    need: "roles.manage",
     children: [
-        { key: '/Admin/Page', label: 'Page', icon:<PlusOutlined />},
-        { key: '/Admin/PaymentReviewPage', label: 'PaymentReview', icon:<PlusOutlined />},
-        { key: '/Admin/RolePage', label: 'Role', icon:<PlusOutlined />},
+      { key: "/Admin/Page", label: "Page", icon: <PlusOutlined /> },
+      { key: "/Admin/PaymentReviewPage", label: "PaymentReview", icon: <PlusOutlined />, need: "payments.manage" },
+      { key: "/Admin/RolePage", label: "Role", icon: <PlusOutlined /> },
     ],
   },
 ];
@@ -65,9 +57,22 @@ const Sidebar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { permissions } = useAuth();
+  const can = (k: string) => permissions.includes(k);
+
+  const filterMenu = (items: MenuItem[]): GroupItem[] =>
+    items
+      .filter((it) => !it.need || can(it.need))
+      .map((it) => ({
+        key: it.key,
+        label: it.label,
+        icon: it.icon,
+        children: it.children ? filterMenu(it.children) : undefined,
+      }));
+
+  const items = useMemo(() => filterMenu(menuItems), [permissions]);
 
   // เส้นทางที่เป็น "กลุ่ม" (มี children)
-  const rootSubmenuKeys = useMemo(() => ["/information", "/category"], []);
+  const rootSubmenuKeys = useMemo(() => ["/information", "/category", "/Admin"], []);
 
   // คีย์ที่เลือกอยู่ (ตามเส้นทางปัจจุบัน)
   const selectedKey = location.pathname;
@@ -111,7 +116,18 @@ const Sidebar = () => {
           onOpenChange={onOpenChange}
           onClick={({ key }) => {
             const path = String(key);
-            if (path.startsWith("/Admin") && !permissions.includes("roles.manage")) {
+            const findItem = (list: MenuItem[]): MenuItem | undefined => {
+              for (const it of list) {
+                if (it.key === path) return it;
+                if (it.children) {
+                  const f = findItem(it.children);
+                  if (f) return f;
+                }
+              }
+              return undefined;
+            };
+            const target = findItem(menuItems);
+            if (target?.need && !can(target.need)) {
               message.warning("คุณไม่มีสิทธิ์เข้าถึง");
               return;
             }

--- a/frontend/src/pages/Promotion/PromotionDetail.tsx
+++ b/frontend/src/pages/Promotion/PromotionDetail.tsx
@@ -5,6 +5,7 @@ import Sidebar from "../../components/Sidebar";
 import type { Promotion } from "../../interfaces/Promotion";
 import type { Game } from "../../interfaces/Game";
 import { getPromotion } from "../../services/promotions";
+import { useAuth } from "../../context/AuthContext";
 import dayjs from "dayjs";
 
 const { Content } = Layout;
@@ -14,6 +15,7 @@ const base_url = import.meta.env.VITE_API_URL || "http://localhost:8088";
 
 export default function PromotionDetail() {
   const { id } = useParams<{ id: string }>();
+  const { token } = useAuth();
   const [promotion, setPromotion] = useState<Promotion | null>(null);
   const [games, setGames] = useState<Game[]>([]);
   const navigate = useNavigate();
@@ -37,7 +39,7 @@ export default function PromotionDetail() {
     const load = async () => {
       if (!id) return;
       try {
-        const data = await getPromotion(Number(id), true);
+        const data = await getPromotion(Number(id), true, token || undefined);
         setPromotion(data);
         if (data.games) {
           setGames(data.games);

--- a/frontend/src/pages/Promotion/PromotionManager.tsx
+++ b/frontend/src/pages/Promotion/PromotionManager.tsx
@@ -37,7 +37,8 @@ export default function PromotionManager() {
   const [games, setGames] = useState<GameLite[]>([]);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [promoFile, setPromoFile] = useState<File | null>(null);
-  const { id: currentUserId, token } = useAuth();
+  const { id: currentUserId, token, permissions } = useAuth();
+  const can = (k: string) => permissions.includes(k);
   const isEdit = useMemo(() => editingId !== null, [editingId]);
   const discountType = Form.useWatch("discount_type", form);
 
@@ -60,8 +61,8 @@ export default function PromotionManager() {
     const load = async () => {
       try {
         const [gameRows, promoRows] = await Promise.all([
-          listGames(),
-          listPromotions(true),
+          listGames(token || undefined),
+          listPromotions(true, token || undefined),
         ]);
         setGames(
           gameRows.map(g => ({
@@ -179,6 +180,7 @@ export default function PromotionManager() {
       render: (_: any, r: Promotion) => (
         <Space>
           <Button
+            disabled={!can('promotions.manage')}
             onClick={() => {
               setEditingId(r.ID);
               form.setFieldsValue({
@@ -201,8 +203,9 @@ export default function PromotionManager() {
             cancelText="ยกเลิก"
             okButtonProps={{ danger: true }}
             onConfirm={() => onDelete(r.ID)}
+            disabled={!can('promotions.manage')}
           >
-            <Button danger>ลบ</Button>
+            <Button danger disabled={!can('promotions.manage')}>ลบ</Button>
           </Popconfirm>
         </Space>
       ),
@@ -297,10 +300,10 @@ export default function PromotionManager() {
               </Form.Item>
 
               <Space>
-                <Button type="primary" onClick={onSubmit}>
+                <Button type="primary" onClick={onSubmit} disabled={!can('promotions.manage')}>
                   {isEdit ? "บันทึกการแก้ไข" : "สร้างโปรโมชัน"}
                 </Button>
-                <Button onClick={() => { form.resetFields(); setEditingId(null); }}>
+                <Button onClick={() => { form.resetFields(); setEditingId(null); }} disabled={!can('promotions.manage')}>
                   ล้างฟอร์ม
                 </Button>
               </Space>

--- a/frontend/src/pages/Workshop/UploadPage.tsx
+++ b/frontend/src/pages/Workshop/UploadPage.tsx
@@ -36,7 +36,8 @@ const UploadPage: React.FC = () => {
   const modId = modIdParam ? Number(modIdParam) : undefined;
 
   // สมมติ useAuth() คืน id กับ token (ถ้าไม่มี token ก็ไม่เป็นไร)
-  const { id: userId, token } = useAuth() as { id?: number; token?: string };
+  const { id: userId, token, permissions } = useAuth() as { id?: number; token?: string; permissions: string[] };
+  const can = (k: string) => permissions.includes(k);
 
   // Game + UserGame
   const [game, setGame] = useState<Game | null>(null);
@@ -47,7 +48,7 @@ const UploadPage: React.FC = () => {
 
   useEffect(() => {
     if (gameId) {
-      getGame(gameId)
+      getGame(gameId, token)
         .then(setGame)
         .catch((e) => {
           console.error("[getGame] failed:", e);
@@ -58,7 +59,7 @@ const UploadPage: React.FC = () => {
 
   useEffect(() => {
     if (modId) {
-      getMod(modId)
+      getMod(modId, token)
         .then((m: any) => {
           setModTitle(m?.title ?? "");
           setModDescription(m?.description ?? "");
@@ -74,7 +75,7 @@ const UploadPage: React.FC = () => {
 
   useEffect(() => {
     if (!userId) return;
-    listUserGames(userId)
+    listUserGames(userId, token)
       .then((rows: any[]) => {
         console.log("[listUserGames] raw:", rows);
         setUserGames(Array.isArray(rows) ? rows : []);
@@ -424,7 +425,7 @@ const UploadPage: React.FC = () => {
             type="primary"
             size="large"
             loading={uploading}
-            disabled={disableSubmit}
+            disabled={disableSubmit || (isEditing ? !can('workshop.moderate') : !can('workshop.create'))}
             style={{ background: "#9254de", borderColor: "#9254de" }}
             onClick={handleUpload}
           >

--- a/frontend/src/routes/text.tsx
+++ b/frontend/src/routes/text.tsx
@@ -53,39 +53,35 @@ const router = createBrowserRouter([
     path: "/",
     element: <Sidebar />,
     children: [
-      { path: "/", element: <Home /> },
-      { path: "/home", element: <Home /> },
-      { path: "/request", element: <Request /> },
-      { path: "/requestinfo", element: <Requestinfo /> },
+      { path: "/", element: <RequirePermission permission="games.read" />, children: [{ path: "/", element: <Home /> }] },
+      { path: "/home", element: <RequirePermission permission="games.read" />, children: [{ path: "/home", element: <Home /> }] },
+
+      { path: "/request", element: <RequirePermission permission="requests.create" />, children: [{ path: "/request", element: <Request /> }] },
+      { path: "/requestinfo", element: <RequirePermission permission="requests.read" />, children: [{ path: "/requestinfo", element: <Requestinfo /> }] },
 
       {
         path: "/information",
+        element: <RequirePermission permission="games.manage" />,
         children: [
           { path: "/information/Add", element: <Add /> },
           { path: "/information/Edit", element: <Edit /> },
         ],
       },
 
-      {
-        path: "/category",
-        children: [
-          { path: "/category/Community", element: <CommunityPage /> },
-          { path: "/category/Payment", element: <PaymentPage /> },
-        ],
-      },
+      { path: "/category/Community", element: <RequirePermission permission="community.read" />, children: [{ path: "/category/Community", element: <CommunityPage /> }] },
+      { path: "/category/Payment", element: <RequirePermission permission="payments.create" />, children: [{ path: "/category/Payment", element: <PaymentPage /> }] },
 
-      { path: "/workshop", element: <WorkshopMain /> },
-      { path: "/workshop/:id", element: <WorkshopDetail /> },
-      { path: "/mod/:id", element: <ModDetail /> },
-      { path: "/upload", element: <Workshop /> },
+      { path: "/workshop", element: <RequirePermission permission="workshop.read" />, children: [{ path: "/workshop", element: <WorkshopMain /> }] },
+      { path: "/workshop/:id", element: <RequirePermission permission="workshop.read" />, children: [{ path: "/workshop/:id", element: <WorkshopDetail /> }] },
+      { path: "/mod/:id", element: <RequirePermission permission="workshop.read" />, children: [{ path: "/mod/:id", element: <ModDetail /> }] },
+      { path: "/upload", element: <RequirePermission permission="workshop.create" />, children: [{ path: "/upload", element: <Workshop /> }] },
 
-      { path: "/promotion", element: <PromotionManager /> },
-      { path: "/promotion/:id", element: <PromotionDetail /> },
-
+      { path: "/promotion", element: <RequirePermission permission="promotions.manage" />, children: [{ path: "/promotion", element: <PromotionManager /> }] },
+      { path: "/promotion/:id", element: <RequirePermission permission="promotions.read" />, children: [{ path: "/promotion/:id", element: <PromotionDetail /> }] },
 
       // 🟣 Refund
-      { path: "/refund", element: <RefundPage /> },
-      { path: "/refund-status", element: <RefundStatusPage refunds={refunds} /> },
+      { path: "/refund", element: <RequirePermission permission="refunds.manage" />, children: [{ path: "/refund", element: <RefundPage /> }] },
+      { path: "/refund-status", element: <RequirePermission permission="refunds.read" />, children: [{ path: "/refund-status", element: <RefundStatusPage refunds={refunds} /> }] },
 
       // 🟣 Admin
       {
@@ -103,18 +99,16 @@ const router = createBrowserRouter([
               />
             ),
           },
-          { path: "/Admin/PaymentReviewPage", element: <AdminPaymentReviewPage /> },
+          {
+            path: "/Admin/PaymentReviewPage",
+            element: <RequirePermission permission="payments.manage" />,
+            children: [{ path: "/Admin/PaymentReviewPage", element: <AdminPaymentReviewPage /> }],
+          },
           { path: "/Admin/RolePage", element: <RoleManagement /> },
         ],
       },
-      {
-        path: "/roles",
-        element: <RoleManagement />
-      },
-      {
-        path: "/roles/:id",
-        element: <RoleEdit />
-      }
+      { path: "/roles", element: <RequirePermission permission="roles.manage" />, children: [{ path: "/roles", element: <RoleManagement /> }] },
+      { path: "/roles/:id", element: <RequirePermission permission="roles.manage" />, children: [{ path: "/roles/:id", element: <RoleEdit /> }] }
     ],
   },
 ]);

--- a/frontend/src/services/promotions.ts
+++ b/frontend/src/services/promotions.ts
@@ -11,20 +11,25 @@ async function handleResponse<T>(res: Response): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-export async function listPromotions(withGames = false): Promise<Promotion[]> {
+export async function listPromotions(withGames = false, token?: string): Promise<Promotion[]> {
   const url = new URL(`${API_URL}/promotions`);
   if (withGames) url.searchParams.set("with", "games");
-  const res = await fetch(url.toString());
+  const res = await fetch(url.toString(), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   return handleResponse<Promotion[]>(res);
 }
 
 export async function getPromotion(
   id: number,
   withGames = false,
+  token?: string,
 ): Promise<Promotion> {
   const url = new URL(`${API_URL}/promotions/${id}`);
   if (withGames) url.searchParams.set("with", "games");
-  const res = await fetch(url.toString());
+  const res = await fetch(url.toString(), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   return handleResponse<Promotion>(res);
 }
 
@@ -61,8 +66,10 @@ export async function deletePromotion(id: number, token?: string): Promise<void>
   }
 }
 
-export async function listGames(): Promise<Game[]> {
-  const res = await fetch(`${API_URL}/game`);
+export async function listGames(token?: string): Promise<Game[]> {
+  const res = await fetch(`${API_URL}/game`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   return handleResponse<Game[]>(res);
 }
 

--- a/frontend/src/services/workshop.ts
+++ b/frontend/src/services/workshop.ts
@@ -51,31 +51,36 @@ function addAliases<T extends Record<string, any>>(row: T) {
 }
 
 // ------------------------------- Games -------------------------------
-export async function listGames(): Promise<Game[]> {
-  // NOTE: โปรเจกต์นี้ใช้ /game สำหรับลิสต์ทั้งหมด
-  const res = await fetch(`${API_URL}/game`);
+export async function listGames(token?: string): Promise<Game[]> {
+  const res = await fetch(`${API_URL}/game`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   return handleResponse<Game[]>(res);
 }
 
-export async function getGame(id: number): Promise<Game> {
-  const games = await listGames();
+export async function getGame(id: number, token?: string): Promise<Game> {
+  const games = await listGames(token);
   const found = games.find((g: any) => (g?.ID ?? g?.id ?? g?.Id) === id);
   if (!found) throw new Error(`Game ${id} not found`);
   return found;
 }
 
 // ----------------------------- UserGames -----------------------------
-export async function listUserGames(userId: number): Promise<UserGame[]> {
+export async function listUserGames(userId: number, token?: string): Promise<UserGame[]> {
   const url = new URL(`${API_URL}/user-games`);
   url.searchParams.set("user_id", String(userId));
-  const res = await fetch(url.toString());
+  const res = await fetch(url.toString(), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   const rows = await handleResponse<any[]>(res);
   return (rows ?? []).map((r) => addAliases<UserGame>(r));
 }
 
 // ------------------------------- Mods --------------------------------
-export async function listMods(gameId?: number): Promise<Mod[]> {
-  const res = await fetch(`${API_URL}/mods`);
+export async function listMods(gameId?: number, token?: string): Promise<Mod[]> {
+  const res = await fetch(`${API_URL}/mods`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   let mods = await handleResponse<Mod[]>(res);
   if (gameId !== undefined) {
     mods = mods.filter(
@@ -85,8 +90,10 @@ export async function listMods(gameId?: number): Promise<Mod[]> {
   return mods;
 }
 
-export async function getMod(id: number): Promise<Mod> {
-  const res = await fetch(`${API_URL}/mods/${id}`);
+export async function getMod(id: number, token?: string): Promise<Mod> {
+  const res = await fetch(`${API_URL}/mods/${id}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   return handleResponse<Mod>(res);
 }
 
@@ -116,33 +123,37 @@ export async function updateMod(
 }
 
 // ----------------------------- Comments ------------------------------
-export async function listComments(threadId: number): Promise<Comment[]> {
+export async function listComments(threadId: number, token?: string): Promise<Comment[]> {
   const url = new URL(`${API_URL}/comments`);
   url.searchParams.set("thread_id", String(threadId));
-  const res = await fetch(url.toString());
+  const res = await fetch(url.toString(), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   return handleResponse<Comment[]>(res);
 }
 
-export async function createComment(payload: CreateCommentRequest): Promise<Comment> {
+export async function createComment(payload: CreateCommentRequest, token?: string): Promise<Comment> {
   const res = await fetch(`${API_URL}/comments`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(token ? { Authorization: `Bearer ${token}` } : {}) },
     body: JSON.stringify(payload),
   });
   return handleResponse<Comment>(res);
 }
 
 // --------------------------- Mod Ratings -----------------------------
-export async function listModRatings(modId: number): Promise<ModRating[]> {
-  const res = await fetch(`${API_URL}/modratings`);
+export async function listModRatings(modId: number, token?: string): Promise<ModRating[]> {
+  const res = await fetch(`${API_URL}/modratings`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   const ratings = await handleResponse<ModRating[]>(res);
   return ratings.filter((r: any) => (r?.mod_id ?? r?.modId ?? r?.ModID) === modId);
 }
 
-export async function createModRating(payload: CreateModRatingRequest): Promise<ModRating> {
+export async function createModRating(payload: CreateModRatingRequest, token?: string): Promise<ModRating> {
   const res = await fetch(`${API_URL}/modratings`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(token ? { Authorization: `Bearer ${token}` } : {}) },
     body: JSON.stringify(payload),
   });
   return handleResponse<ModRating>(res);


### PR DESCRIPTION
## Summary
- add `/me` endpoint returning user details and permissions
- secure public routes and tighten CORS
- refresh auth state on frontend and gate routes & menu by permissions

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `npm run lint` *(fails: Unexpected any)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c265d8b4f4832ab43339ab069b69a9