### PR TITLE
Wrap root with Ant Design context

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,13 +5,16 @@ import router from "./routes/text";          // ไม่ต้องใส่ .
 import { RouterProvider } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
 import { CartProvider } from "./context/CartContext";   // ⬅️ เพิ่มบรรทัดนี้
+import { App as AntdApp } from "antd";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <AuthProvider>
-      <CartProvider>                           {/* ⬅️ ครอบ Router ด้วย CartProvider */}
-        <RouterProvider router={router} />
-      </CartProvider>
-    </AuthProvider>
+    <AntdApp>
+      <AuthProvider>
+        <CartProvider>                           {/* ⬅️ ครอบ Router ด้วย CartProvider */}
+          <RouterProvider router={router} />
+        </CartProvider>
+      </AuthProvider>
+    </AntdApp>
   </StrictMode>
 );

--- a/frontend/src/pages/Admin/AdminPaymentReviewPage.tsx
+++ b/frontend/src/pages/Admin/AdminPaymentReviewPage.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Card, Table, Tag, Space, Button, Typography, Modal, Input, Image,
-  App, Tooltip, Select, message as antdMessage
+  App, Tooltip, Select
 } from "antd";
 import {
   CheckCircleOutlined, CloseCircleOutlined, EyeOutlined,
@@ -56,10 +56,7 @@ function normalizeRow(r: any): ReviewablePayment {
 }
 
 export default function AdminPaymentReviewPage() {
-  // ใช้ App.useApp() ถ้ามี <App> ครอบ root; ถ้าไม่มี fallback เป็น antdMessage/Modal
-  const appCtx = App.useApp?.();
-  const msg = appCtx?.message ?? antdMessage;
-  const modal = appCtx?.modal ?? Modal;
+  const { modal, message } = App.useApp();
 
   const { id: userId, token } = useAuth() as { id: number | null; token?: string };
 
@@ -88,7 +85,7 @@ export default function AdminPaymentReviewPage() {
       setRows(data.map(normalizeRow));
     } catch (e) {
       console.error(e);
-      msg.error("โหลดข้อมูลการชำระเงินล้มเหลว");
+      message.error("โหลดข้อมูลการชำระเงินล้มเหลว");
       setRows([]);
     } finally {
       setLoading(false);
@@ -123,10 +120,10 @@ export default function AdminPaymentReviewPage() {
               p.id === id ? { ...p, status: "APPROVED", reject_reason: null, order_status: "PAID" } : p,
             ),
           );
-          msg.success("อนุมัติการชำระเงินแล้ว");
+          message.success("อนุมัติการชำระเงินแล้ว");
         } catch (e) {
           console.error(e);
-          msg.error("ไม่สามารถอนุมัติได้");
+          message.error("ไม่สามารถอนุมัติได้");
         }
       },
     });
@@ -138,7 +135,7 @@ export default function AdminPaymentReviewPage() {
   };
 
   const submitReject = async () => {
-    if (!rejectText.trim()) return msg.warning("กรอกเหตุผลที่ปฏิเสธก่อน");
+    if (!rejectText.trim()) return message.warning("กรอกเหตุผลที่ปฏิเสธก่อน");
     const id = rejectOpen.id!;
     try {
       // ส่งได้ทั้ง reason และ reject_reason เพื่อเข้ากันได้หลาย backend
@@ -154,11 +151,11 @@ export default function AdminPaymentReviewPage() {
             : p,
         ),
       );
-      msg.success("ปฏิเสธการชำระเงินแล้ว");
+      message.success("ปฏิเสธการชำระเงินแล้ว");
       setRejectOpen({ open: false });
     } catch (e) {
       console.error(e);
-      msg.error("ไม่สามารถปฏิเสธได้");
+      message.error("ไม่สามารถปฏิเสธได้");
     }
   };
 


### PR DESCRIPTION
## Summary
- wrap React root with Ant Design's `App` provider for context access
- simplify admin payment review page by using `App.useApp` for modal and message APIs

## Testing
- `npm run lint` *(fails: numerous pre-existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c275bf99808322b41f4090aec0a6ef