### PR TITLE
Add order key reveal endpoints

### DIFF
--- a/backend/controllers/order_keys.go
+++ b/backend/controllers/order_keys.go
@@ -13,7 +13,7 @@ import (
 type orderKeyResp struct {
 	ID         uint    `json:"id"`
 	GameName   string  `json:"game_name"`
-	KeyCode    *string `json:"key_code"`
+	KeyCode    *string `json:"key_code,omitempty"`
 	IsRevealed bool    `json:"is_revealed"`
 }
 


### PR DESCRIPTION
## Summary
- implement authenticated endpoints to list and reveal game keys
- hide key codes in listing until reveal

## Testing
- `cd backend && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c2852e0c5c832289c8096f151ad65b