### PR TITLE
Grant user games when payments are approved

### DIFF
--- a/backend/controllers/payment_controller.go
+++ b/backend/controllers/payment_controller.go
@@ -304,15 +304,16 @@ func changePaymentStatus(paymentID uint, newStatus string, rejectReason *string)
 					if err := tx.Save(&key).Error; err != nil {
 						return err
 					}
-					ug := entity.UserGame{
-						UserID:             ord.UserID,
-						GameID:             item.GameID,
-						GrantedAt:          time.Now(),
-						GrantedByPaymentID: p.ID,
-					}
-					if err := tx.Where("user_id = ? AND game_id = ?", ord.UserID, item.GameID).FirstOrCreate(&ug).Error; err != nil {
-						return err
-					}
+				}
+
+				ug := entity.UserGame{
+					UserID:             ord.UserID,
+					GameID:             item.GameID,
+					GrantedAt:          time.Now(),
+					GrantedByPaymentID: p.ID,
+				}
+				if err := tx.Where("user_id = ? AND game_id = ?", ord.UserID, item.GameID).FirstOrCreate(&ug).Error; err != nil {
+					return err
 				}
 			}
 			return nil


### PR DESCRIPTION
## Summary
- reserve key games for each order item when approving payments
- record granted games in `user_games` within the payment transaction

## Testing
- `go test ./...` *(fails: command hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c286b98ca8832289f56cdaa3a19c40