### PR TITLE
fix: hard delete review likes to allow re-like

### DIFF
--- a/backend/controllers/reviews.go
+++ b/backend/controllers/reviews.go
@@ -92,9 +92,15 @@ func UpdateReview(c *gin.Context) {
 	}
 	// apply updatable fields
 	update := map[string]any{}
-	if payload.ReviewTitle != "" { update["review_title"] = payload.ReviewTitle }
-	if payload.ReviewText != "" { update["review_text"] = payload.ReviewText }
-	if payload.Rating != 0     { update["rating"] = payload.Rating }
+	if payload.ReviewTitle != "" {
+		update["review_title"] = payload.ReviewTitle
+	}
+	if payload.ReviewText != "" {
+		update["review_text"] = payload.ReviewText
+	}
+	if payload.Rating != 0 {
+		update["rating"] = payload.Rating
+	}
 	if err := db.Model(&row).Updates(update).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "update failed: " + err.Error()})
 		return
@@ -156,7 +162,7 @@ func ToggleReviewLike(c *gin.Context) {
 		}
 	} else {
 		// found => toggle off (delete)
-		if err := db.Delete(&like).Error; err != nil {
+		if err := db.Unscoped().Delete(&like).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "unlike failed: " + err.Error()})
 			return
 		}


### PR DESCRIPTION
## Summary
- ensure ToggleReviewLike hard deletes existing likes

## Testing
- `go test -list .`
- `go run test_toggle_like.go` (creates review and toggles like/unlike/like again)


------
https://chatgpt.com/codex/tasks/task_e_68c28efab30c832991f7fbb4f74d6c54