### PR TITLE
Drop stale idx_user_game before migrate

### DIFF
--- a/backend/configs/db.go
+++ b/backend/configs/db.go
@@ -43,15 +43,17 @@ func SetupDatabase() {
 	}
 
 	// สร้างตารางให้ครบ
-	// ลบ index เดิมของ Review หากมีอยู่ก่อนทำ AutoMigrate
-	if db.Migrator().HasIndex(&entity.Review{}, "idx_user_game") {
-		db.Migrator().DropIndex(&entity.Review{}, "idx_user_game")
-	}
-	if err := db.AutoMigrate(
-		&entity.User{},
-		&entity.Game{},
-		&entity.KeyGame{},
-		&entity.Thread{},
+        // ลบ index เดิมของ Review หากมีอยู่ก่อนทำ AutoMigrate
+        if db.Migrator().HasIndex(&entity.Review{}, "idx_user_game") {
+                db.Migrator().DropIndex(&entity.Review{}, "idx_user_game")
+        }
+       // บังคับลบ index ที่ค้างในฐานข้อมูลก่อน migrate
+       db.Exec("DROP INDEX IF EXISTS idx_user_game")
+        if err := db.AutoMigrate(
+                &entity.User{},
+                &entity.Game{},
+                &entity.KeyGame{},
+                &entity.Thread{},
 		&entity.UserGame{},
 		&entity.Comment{},
 		&entity.Reaction{},


### PR DESCRIPTION
## Summary
- Drop lingering `idx_user_game` index before running migrations to avoid conflicts

## Testing
- `go build ./...`
- `go run main.go` *(fails: index idx_user_game already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a61334408329855db27f1c670eec