### PR TITLE
Fix review unlike error handling

### DIFF
--- a/backend/controllers/reviews.go
+++ b/backend/controllers/reviews.go
@@ -228,7 +228,10 @@ func ToggleReviewLike(c *gin.Context) {
 	liked := true
 	if err == nil {
 		// มีแล้ว => ลบ (unlike)
-		_ = db.Delete(&like).Error
+		if err := db.Unscoped().Delete(&like).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "toggle_failed"})
+			return
+		}
 		liked = false
 	} else if err != gorm.ErrRecordNotFound {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "toggle_failed"})


### PR DESCRIPTION
## Summary
- ensure toggling review likes performs hard deletes and handles DB errors

## Testing
- `go test ./...`
- `curl -s -o /dev/null -w "%{http_code}\n" -X POST -H "Content-Type: application/json" -d '{"user_id":1}' http://localhost:8088/reviews/1/toggle_like` *(fails: FOREIGN KEY constraint)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f362a40c8329beb0454d881da57c