### PR TITLE
Use hard delete for reviews

### DIFF
--- a/backend/controllers/reviews.go
+++ b/backend/controllers/reviews.go
@@ -166,7 +166,7 @@ func UpdateReview(c *gin.Context) {
 func DeleteReview(c *gin.Context) {
 	id := c.Param("id")
 	db := configs.DB()
-	if err := db.Delete(&entity.Review{}, id).Error; err != nil {
+	if err := db.Unscoped().Delete(&entity.Review{}, id).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "delete_failed"})
 		return
 	}


### PR DESCRIPTION
## Summary
- hard delete reviews instead of soft delete to allow rewriting after removal

## Testing
- `sqlite3 gameshop-community.db "INSERT INTO reviews (review_title, review_text, rating, user_id, game_id, created_at, updated_at) VALUES ('t1', 'text1', 5, 2, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);"`
- `sqlite3 gameshop-community.db "DELETE FROM reviews WHERE id=4;"`
- `sqlite3 gameshop-community.db "INSERT INTO reviews (review_title, review_text, rating, user_id, game_id, created_at, updated_at) VALUES ('t1', 'text1', 5, 2, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);"`


------
https://chatgpt.com/codex/tasks/task_e_68c3013c533c8329bf26e1083c00fc8e