### PR TITLE
feat: show review count in review section header

### DIFF
--- a/frontend/src/components/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection.tsx
@@ -220,7 +220,7 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({ gameId, allowCreate = tru
   const header = useMemo(
     () => (
       <Space style={{ width: "100%", justifyContent: "space-between" }}>
-        <h3 style={{ margin: 0 }}>รีวิวทั้งหมด</h3>
+        <h3 style={{ margin: 0 }}>รีวิวทั้งหมด ({items.length})</h3>
         {canCreate && (
           <Button type="primary" icon={<Plus size={16} />} onClick={onCreate}>
             สร้างรีวิว
@@ -228,7 +228,7 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({ gameId, allowCreate = tru
         )}
       </Space>
     ),
-    [canCreate]
+    [canCreate, items.length]
   );
 
   return (


### PR DESCRIPTION
## Summary
- display number of reviews in ReviewSection header

## Testing
- `npm --prefix frontend run lint` *(fails: 'reviewCount' is assigned a value but never used etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c305f442b0832991613945460ac20b