### PR TITLE
feat: fill heart icon on like

### DIFF
--- a/frontend/src/components/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection.tsx
@@ -245,7 +245,11 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({ gameId, allowCreate = tru
               key={r.ID}
               actions={[
                 <Space key="like" onClick={() => handleToggleLike(r)} style={{ cursor: "pointer" }}>
-                  <Heart size={18} className={r.likedByMe ? "text-red-400" : "text-gray-500"} />
+                  <Heart
+                    size={18}
+                    fill={r.likedByMe ? "currentColor" : "none"}
+                    className={r.likedByMe ? "text-red-400" : "text-gray-500"}
+                  />
                   <span>{r.likes ?? 0}</span>
                 </Space>,
                 userId === r.user_id ? (


### PR DESCRIPTION
## Summary
- add conditional fill and color to Heart icon in review section when liked

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 41 problems (39 errors, 2 warnings))*
- `npm run build` *(fails: TypeScript errors across multiple files)*


------
https://chatgpt.com/codex/tasks/task_e_68c307365c4c832985dd78e293d88276