### PR TITLE
Add problem report resolution support

### DIFF
--- a/backend/entity/ProblemReply.go
+++ b/backend/entity/ProblemReply.go
@@ -5,21 +5,21 @@ import "gorm.io/gorm"
 // Reply จากแอดมิน
 type ProblemReply struct {
 	gorm.Model
-	ReportID uint
-	AdminID  uint
-	Message  string
+	ReportID uint   `json:"report_id"`
+	AdminID  uint   `json:"admin_id"`
+	Message  string `json:"message"`
 
 	// Relations
-	Report      ProblemReport
-	Attachments []ProblemReplyAttachment `gorm:"foreignKey:ReplyID;references:ID"`
+	Report      ProblemReport            `json:"report"`
+	Attachments []ProblemReplyAttachment `json:"attachments" gorm:"foreignKey:ReplyID;references:ID"`
 }
 
 // ไฟล์แนบของ Reply (แอดมินแนบ)
 type ProblemReplyAttachment struct {
 	gorm.Model
-	ReplyID  uint
-	FilePath string
+	ReplyID  uint   `json:"reply_id"`
+	FilePath string `json:"file_path"`
 
 	// Relation ย้อนกลับ (ช่วยให้ GORM map FK ชัดเจน)
-	Reply ProblemReply `gorm:"foreignKey:ReplyID;references:ID"`
+	Reply ProblemReply `json:"-" gorm:"foreignKey:ReplyID;references:ID"`
 }

--- a/backend/entity/problem_reply_attachment.go
+++ b/backend/entity/problem_reply_attachment.go
@@ -1,8 +1,0 @@
-// entity/problem_reply_attachment.go
-package entity
-
-type ProblemReplyAttachment struct {
-    ID     uint   `gorm:"primaryKey" json:"id"`
-    ReplyID uint   `json:"reply_id"`
-    FilePath string `json:"file_path"`
-}

--- a/backend/entity/problem_report.go
+++ b/backend/entity/problem_report.go
@@ -8,21 +8,15 @@ import (
 
 type ProblemReport struct {
 	gorm.Model
-	Title       string
-	Description string
-	Status      string
-	UserID      uint
-	ResolvedAt  *time.Time
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Category    string     `json:"category"`
+	Status      string     `json:"status"`
+	UserID      uint       `json:"user_id"`
+	ResolvedAt  *time.Time `json:"resolved_at"`
 
 	// Relations
-	User        User
-	Attachments []ProblemAttachment `gorm:"foreignKey:ReportID"`
-	Replies     []ProblemReply      `gorm:"foreignKey:ReportID"`
-}
-
-// ไฟล์แนบของ Report (ของผู้ใช้)
-type ProblemAttachment struct {
-	gorm.Model
-	FilePath string
-	ReportID uint
+	User        User                `json:"user"`
+	Attachments []ProblemAttachment `json:"attachments" gorm:"foreignKey:ReportID"`
+	Replies     []ProblemReply      `json:"replies" gorm:"foreignKey:ReportID"`
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -74,10 +74,10 @@ func main() {
 		router.POST("/upload/game", controllers.UploadGame)
 
 		// ===== Threads =====
-		router.POST("/threads", controllers.CreateThread)             // multipart: title, content, game_id, user_id, images[]
-		router.GET("/threads", controllers.FindThreads)               // ?game_id=&q=
+		router.POST("/threads", controllers.CreateThread) // multipart: title, content, game_id, user_id, images[]
+		router.GET("/threads", controllers.FindThreads)   // ?game_id=&q=
 		router.GET("/threads/:id", controllers.FindThreadByID)
-		router.PUT("/threads/:id", controllers.UpdateThread)          // แก้ title/content
+		router.PUT("/threads/:id", controllers.UpdateThread) // แก้ title/content
 		router.DELETE("/threads/:id", controllers.DeleteThread)
 
 		// ===== Comments (flat) =====
@@ -85,8 +85,8 @@ func main() {
 		router.GET("/threads/:id/comments", controllers.FindCommentsByThread)
 		router.DELETE("/comments/:id", controllers.DeleteComment)
 
-// ===== Thread Likes =====
-router.POST("/threads/:id/toggle_like", controllers.ToggleThreadLike)
+		// ===== Thread Likes =====
+		router.POST("/threads/:id/toggle_like", controllers.ToggleThreadLike)
 		// -------- UserGames --------
 		router.POST("/user-games", controllers.CreateUserGame)
 		router.GET("/user-games", controllers.FindUserGames) // ?user_id=
@@ -150,8 +150,10 @@ router.POST("/threads/:id/toggle_like", controllers.ToggleThreadLike)
 		// ===== Problem Reports =====
 		router.POST("/reports", controllers.CreateReport)
 		router.GET("/reports", controllers.FindReports)
+		router.GET("/reports/resolved", controllers.FindResolvedReports)
 		router.GET("/reports/:id", controllers.GetReportByID)
 		router.PUT("/reports/:id", controllers.UpdateReport)
+		router.PUT("/reports/:id/resolve", controllers.ResolveReport)
 		router.DELETE("/reports/:id", controllers.DeleteReport)
 		router.POST("/reports/:id/reply", controllers.ReplyReport)
 

--- a/frontend/src/interfaces/problem_report.ts
+++ b/frontend/src/interfaces/problem_report.ts
@@ -29,6 +29,7 @@ export interface ProblemReport {
   reply: any;
   ID: number;
   title: string;
+  category: string;
   description: string;
   status: string;
   created_at: string;

--- a/frontend/src/pages/Admin/ResolvedReportPage.tsx
+++ b/frontend/src/pages/Admin/ResolvedReportPage.tsx
@@ -1,7 +1,7 @@
 // src/pages/Admin/ResolvedReportsPage.tsx
 import { useEffect, useState } from "react";
 import { Card, Button, Typography, Tag, Modal } from "antd";
-import { fetchReports } from "../../services/Report";
+import { fetchResolvedReports } from "../../services/Report";
 import type { ProblemReport } from "../../interfaces/problem_report";
 import { useNavigate } from "react-router-dom";
 
@@ -18,8 +18,8 @@ export default function ResolvedReportsPage() {
   useEffect(() => {
     const load = async () => {
       try {
-        const all = await fetchReports();
-        setItems((all || []).filter((i) => i.status === "resolved"));
+        const all = await fetchResolvedReports();
+        setItems(all || []);
       } catch (e) {
         console.error(e);
       }
@@ -112,7 +112,9 @@ export default function ResolvedReportsPage() {
 
               {reply && (
                 <div style={{ marginTop: 12 }}>
-                  <p style={{ ...textStyle, marginBottom: 8 }}>📨 Admin Reply:</p>
+                  <p style={{ ...textStyle, marginBottom: 8 }}>
+                    📨 Admin Reply:
+                  </p>
                   <div
                     style={{
                       background: "#141322",
@@ -126,8 +128,12 @@ export default function ResolvedReportsPage() {
 
                   {reply.attachments && reply.attachments.length > 0 && (
                     <div style={{ marginTop: 15 }}>
-                      <p style={{ ...textStyle, marginBottom: 8 }}>📎 Reply Attachments:</p>
-                      <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+                      <p style={{ ...textStyle, marginBottom: 8 }}>
+                        📎 Reply Attachments:
+                      </p>
+                      <div
+                        style={{ display: "flex", flexWrap: "wrap", gap: 10 }}
+                      >
                         {reply.attachments.map((att) => {
                           const path = (att as any).file_path || "";
                           const isImage = path

--- a/frontend/src/pages/Report/ReportPage.tsx
+++ b/frontend/src/pages/Report/ReportPage.tsx
@@ -31,8 +31,9 @@ export default function ReportPage() {
 
       await createReport({
         title: values.title,
+        category: values.category,
         description: values.description,
-        user_id: userId,          // ✅ ใช้ snake_case ให้ตรง backend
+        user_id: userId, // ✅ ใช้ snake_case ให้ตรง backend
         game_id: DEFAULT_GAME_ID,
         status: "open",
         files,
@@ -101,13 +102,25 @@ export default function ReportPage() {
           >
             <Select placeholder="เลือกหมวดปัญหา">
               <Select.Option value="technical">⚙️ ปัญหาทางเทคนิค</Select.Option>
-              <Select.Option value="billing">💳 ปัญหาการเรียกเก็บเงิน</Select.Option>
-              <Select.Option value="login">🔐 เข้าสู่ระบบ/ยืนยันตัวตน</Select.Option>
-              <Select.Option value="ui">🖥️ หน้าตา/การใช้งาน (UI/UX)</Select.Option>
-              <Select.Option value="performance">🚀 ประสิทธิภาพช้า/หน่วง</Select.Option>
+              <Select.Option value="billing">
+                💳 ปัญหาการเรียกเก็บเงิน
+              </Select.Option>
+              <Select.Option value="login">
+                🔐 เข้าสู่ระบบ/ยืนยันตัวตน
+              </Select.Option>
+              <Select.Option value="ui">
+                🖥️ หน้าตา/การใช้งาน (UI/UX)
+              </Select.Option>
+              <Select.Option value="performance">
+                🚀 ประสิทธิภาพช้า/หน่วง
+              </Select.Option>
               <Select.Option value="crash">💥 แอปค้าง/เด้ง</Select.Option>
-              <Select.Option value="purchase">🛒 ซื้อ/ชำระเงินผิดพลาด</Select.Option>
-              <Select.Option value="content">📦 เนื้อหาหาย/ไม่ถูกต้อง</Select.Option>
+              <Select.Option value="purchase">
+                🛒 ซื้อ/ชำระเงินผิดพลาด
+              </Select.Option>
+              <Select.Option value="content">
+                📦 เนื้อหาหาย/ไม่ถูกต้อง
+              </Select.Option>
               <Select.Option value="feedback">💬 ข้อเสนอแนะ</Select.Option>
               <Select.Option value="other">❓ อื่น ๆ</Select.Option>
             </Select>
@@ -126,7 +139,10 @@ export default function ReportPage() {
             name="description"
             rules={[{ required: true, message: "กรุณากรอกรายละเอียด" }]}
           >
-            <Input.TextArea rows={4} placeholder="อธิบายรายละเอียดของปัญหาให้ชัดเจน" />
+            <Input.TextArea
+              rows={4}
+              placeholder="อธิบายรายละเอียดของปัญหาให้ชัดเจน"
+            />
           </Form.Item>
 
           <Form.Item
@@ -140,15 +156,19 @@ export default function ReportPage() {
               listType="picture-card"
               fileList={fileList}
               onPreview={(file) => {
-                window.open((file as any).url || (file as any).thumbUrl, "_blank");
+                window.open(
+                  (file as any).url || (file as any).thumbUrl,
+                  "_blank",
+                );
               }}
               onChange={({ fileList: fl }) => setFileList(fl)}
               onRemove={(file) => {
                 setFileList((prev) => prev.filter((f) => f.uid !== file.uid));
-              }}  // ✅ แก้จาก })} เป็น }}
+              }} // ✅ แก้จาก })} เป็น }}
               beforeUpload={(file) => {
                 const isImage = file.type?.startsWith("image/");
-                if (!isImage) message.error("อัปโหลดได้เฉพาะไฟล์รูปภาพเท่านั้น");
+                if (!isImage)
+                  message.error("อัปโหลดได้เฉพาะไฟล์รูปภาพเท่านั้น");
                 return false; // ไม่อัปโหลดทันที ให้รวมส่งตอน submit
               }}
               maxCount={3}

--- a/frontend/src/services/Report.ts
+++ b/frontend/src/services/Report.ts
@@ -5,17 +5,21 @@ import type { ProblemReport } from "../interfaces/problem_report";
 export type CreateReportInput = {
   title: string;
   description: string;
-  user_id: number;   // ✅ snake_case ให้ตรงกับ backend
+  category: string;
+  user_id: number; // ✅ snake_case ให้ตรงกับ backend
   game_id: number;
   status?: string;
   files?: File[];
 };
 
 // ✅ สร้างรายงาน (multipart/form-data)
-export async function createReport(input: CreateReportInput): Promise<ProblemReport> {
+export async function createReport(
+  input: CreateReportInput,
+): Promise<ProblemReport> {
   const fd = new FormData();
   fd.append("title", input.title);
   fd.append("description", input.description);
+  fd.append("category", input.category);
   fd.append("user_id", String(input.user_id));
   fd.append("game_id", String(input.game_id));
   fd.append("status", input.status ?? "open");
@@ -47,7 +51,7 @@ export async function getReportByID(id: number): Promise<ProblemReport> {
 // ✅ ตอบกลับรายงาน (Admin reply)
 export async function replyReport(
   id: number,
-  payload: { admin_id: number; message: string; files?: File[] }
+  payload: { admin_id: number; message: string; files?: File[] },
 ): Promise<ProblemReport> {
   const fd = new FormData();
   fd.append("admin_id", String(payload.admin_id));
@@ -64,4 +68,10 @@ export async function replyReport(
 export async function resolveReport(id: number): Promise<ProblemReport> {
   const { data } = await api.put(`/reports/${id}/resolve`);
   return data as ProblemReport;
+}
+
+// ✅ ดึงรายการที่แก้ไขแล้ว
+export async function fetchResolvedReports(): Promise<ProblemReport[]> {
+  const { data } = await api.get("/reports/resolved");
+  return (Array.isArray(data) ? data : data?.items || []) as ProblemReport[];
 }


### PR DESCRIPTION
## Summary
- track report category and expose JSON fields
- allow admins to resolve reports and list resolved reports
- support resolved endpoints in React UI and API service

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c3158f75a88323a9c3c96635e0266e