### PR TITLE
feat: add report link and admin badge

### DIFF
--- a/frontend/src/components/AdminPageBadge.tsx
+++ b/frontend/src/components/AdminPageBadge.tsx
@@ -1,28 +1,9 @@
 // src/components/AdminPageBadge.tsx
-import { useEffect, useState } from "react";
-import { fetchReports } from "../services/Report";
-import type { ProblemReport } from "../interfaces/problem_report";
+import { useReportNewCount } from "../hooks/useReportNewCount";
 
 export default function AdminPageBadge() {
-  const [count, setCount] = useState(0);
-
-  const load = async () => {
-    try {
-      const items: ProblemReport[] = await fetchReports();
-      // นับเฉพาะที่ยังไม่ resolved
-      const pending = (items || []).filter((r) => r.status !== "resolved")
-        .length;
-      setCount(pending);
-    } catch (e) {
-      console.error("[AdminPageBadge] fetchReports error:", e);
-    }
-  };
-
-  useEffect(() => {
-    load(); // ครั้งแรก
-    const t = window.setInterval(load, 8000); // โพลล์ทุก 8 วิ
-    return () => clearInterval(t);
-  }, []);
+  // นับจำนวนคำร้องใหม่ ๆ ที่ยังไม่เห็น
+  const count = useReportNewCount();
 
   return (
     <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import type { MenuProps } from "antd";
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import { PlusOutlined } from "@ant-design/icons";
 import { useEffect, useMemo, useState } from "react";
+import AdminPageBadge from "./AdminPageBadge";
 
 const { Sider } = Layout;
 type GroupItem = Required<MenuProps>["items"][number];
@@ -50,10 +51,14 @@ const items: GroupItem[] = [
     label:'การคืนเงินผู้ใช้',
   },
   {
+    key: '/report',
+    label: 'รายงานปัญหา',
+  },
+  {
     key: '/Admin',
     label:'Admin',
     children: [
-        { key: '/Admin/Page', label: 'Page', icon:<PlusOutlined />},
+        { key: '/Admin/Page', label: <AdminPageBadge />, icon:<PlusOutlined />},
         { key: '/Admin/PaymentReviewPage', label: 'PaymentReview', icon:<PlusOutlined />},
         { key: '/Admin/RolePage', label: 'Role', icon:<PlusOutlined />},
     ],

--- a/frontend/src/routes/text.tsx
+++ b/frontend/src/routes/text.tsx
@@ -15,6 +15,8 @@ import WorkshopMain from "../pages/Workshop/MainPage";
 import WorkshopDetail from "../pages/Workshop/WorkshopDetail";
 import ModDetail from "../pages/Workshop/ModDetail";
 import Workshop from "../pages/Workshop/UploadPage";
+import ReportPage from "../pages/Report/ReportPage";
+import ReportSuccessPage from "../pages/Report/ReportSuccess";
 
 import PromotionManager from "../pages/Promotion/PromotionManager";
 import PromotionDetail from "../pages/Promotion/PromotionDetail";
@@ -51,8 +53,8 @@ const router = createBrowserRouter([
 
 
       // ✅ Report
-      //{ path: "/report", element: <ReportPage /> },
-      //{ path: "/report/success", element: <ReportSuccessPage /> },
+      { path: "report", element: <ReportPage /> },
+      { path: "report/success", element: <ReportSuccessPage /> },
 
       // === กลุ่ม information
       { path: "information/Add", element: <Add /> },


### PR DESCRIPTION
## Summary
- show new report count on admin page link via `useReportNewCount`
- add report problem link in sidebar and expose report routes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: many TypeScript lint errors)
- `go test ./...` (no output; command hung)


------
https://chatgpt.com/codex/tasks/task_e_68c38e6541888323b59f6971df148fb4