### PR TITLE
feat: add order key reveal endpoints

### DIFF
--- a/backend/controllers/order_keys.go
+++ b/backend/controllers/order_keys.go
@@ -1,0 +1,106 @@
+package controllers
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+	"github.com/gin-gonic/gin"
+)
+
+// maskKeyCode masks a key code leaving only the last 4 characters visible.
+func maskKeyCode(code string) string {
+	if len(code) <= 4 {
+		return strings.Repeat("*", len(code))
+	}
+	return strings.Repeat("*", len(code)-4) + code[len(code)-4:]
+}
+
+// GET /orders/:orderId/keys
+// เจ้าของ order เท่านั้น และต้องชำระเงินแล้ว
+func FindOrderKeys(c *gin.Context) {
+	uidAny, ok := c.Get("userID")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	userID := uidAny.(uint)
+	orderID := c.Param("orderId")
+
+	db := configs.DB()
+
+	var order entity.Order
+	if tx := db.First(&order, orderID); tx.Error != nil || tx.RowsAffected == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "order not found"})
+		return
+	}
+	if order.UserID != userID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+	if order.OrderStatus != entity.OrderPaid && order.OrderStatus != entity.OrderFulfilled {
+		c.JSON(http.StatusForbidden, gin.H{"error": "order not paid"})
+		return
+	}
+
+	var keys []entity.KeyGame
+	if err := db.Preload("Game").Joins("JOIN order_items ON key_games.owned_by_order_item_id = order_items.id").Where("order_items.order_id = ?", order.ID).Find(&keys).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	for i := range keys {
+		keys[i].KeyCode = maskKeyCode(keys[i].KeyCode)
+	}
+
+	c.JSON(http.StatusOK, keys)
+}
+
+// POST /orders/:orderId/keys/:keyId/reveal
+// เจ้าของ order เท่านั้น คืนคีย์จริง และบันทึกว่าเปิดเผยแล้ว
+func RevealOrderKey(c *gin.Context) {
+	uidAny, ok := c.Get("userID")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	userID := uidAny.(uint)
+	orderID := c.Param("orderId")
+	keyID := c.Param("keyId")
+
+	db := configs.DB()
+
+	var order entity.Order
+	if tx := db.First(&order, orderID); tx.Error != nil || tx.RowsAffected == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "order not found"})
+		return
+	}
+	if order.UserID != userID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+	if order.OrderStatus != entity.OrderPaid && order.OrderStatus != entity.OrderFulfilled {
+		c.JSON(http.StatusForbidden, gin.H{"error": "order not paid"})
+		return
+	}
+
+	var key entity.KeyGame
+	if tx := db.Preload("Game").Joins("JOIN order_items ON key_games.owned_by_order_item_id = order_items.id").Where("order_items.order_id = ? AND key_games.id = ?", order.ID, keyID).First(&key); tx.Error != nil || tx.RowsAffected == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "key not found"})
+		return
+	}
+
+	if !key.IsRevealed {
+		now := time.Now()
+		key.IsRevealed = true
+		key.RevealedAt = &now
+		if err := db.Save(&key).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, key)
+}

--- a/backend/entity/keygame.go
+++ b/backend/entity/keygame.go
@@ -1,7 +1,11 @@
 // entity/key_game.go
 package entity
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type KeyGame struct {
 	gorm.Model
@@ -14,4 +18,8 @@ type KeyGame struct {
 	// จองคีย์ให้ OrderItem ไหน (nil = ว่าง)
 	OwnedByOrderItemID *uint      `json:"owned_by_order_item_id"`
 	OwnedByOrderItem   *OrderItem `gorm:"foreignKey:OwnedByOrderItemID" json:"owned_by_order_item,omitempty"`
+
+	// สถานะการเปิดเผยคีย์
+	IsRevealed bool       `json:"is_revealed" gorm:"default:false"`
+	RevealedAt *time.Time `json:"revealed_at"`
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -72,9 +72,9 @@ func main() {
 		router.POST("/upload/game", controllers.UploadGame) // ลงทะเบียนครั้งเดียว
 
 		// -------- Threads (READ only = public) --------
-		router.GET("/threads", controllers.FindThreads)                        // ?game_id=&q=
-		router.GET("/threads/:id", controllers.FindThreadByID)                 // รายละเอียดเธรด
-		router.GET("/threads/:id/comments", controllers.FindCommentsByThread)  // คอมเมนต์แบบแถวเดียว
+		router.GET("/threads", controllers.FindThreads)                       // ?game_id=&q=
+		router.GET("/threads/:id", controllers.FindThreadByID)                // รายละเอียดเธรด
+		router.GET("/threads/:id/comments", controllers.FindCommentsByThread) // คอมเมนต์แบบแถวเดียว
 
 		// -------- UserGames --------
 		router.POST("/user-games", controllers.CreateUserGame)
@@ -181,6 +181,10 @@ func main() {
 		authList.PUT("/order-items/:id/qty", controllers.UpdateOrderItemQty)
 		authList.DELETE("/order-items/:id", controllers.DeleteOrderItem)
 
+		// Order Keys
+		authList.GET("/orders/:orderId/keys", controllers.FindOrderKeys)
+		authList.POST("/orders/:orderId/keys/:keyId/reveal", controllers.RevealOrderKey)
+
 		// Payments (write/action)
 		authList.POST("/payments", controllers.CreatePayment)
 		authList.PATCH("/payments/:id", controllers.UpdatePayment)
@@ -188,8 +192,8 @@ func main() {
 		authList.POST("/payments/:id/reject", controllers.RejectPayment)
 
 		// -------- Threads (WRITE only = ต้อง auth) --------
-		authList.POST("/threads", controllers.CreateThread)          // multipart: title, content, game_id, images[]
-		authList.PUT("/threads/:id", controllers.UpdateThread)       // แก้ title/content
+		authList.POST("/threads", controllers.CreateThread)    // multipart: title, content, game_id, images[]
+		authList.PUT("/threads/:id", controllers.UpdateThread) // แก้ title/content
 		authList.DELETE("/threads/:id", controllers.DeleteThread)
 		authList.POST("/threads/:id/comments", controllers.CreateComment)
 		authList.DELETE("/comments/:id", controllers.DeleteComment)


### PR DESCRIPTION
## Summary
- track key reveal status
- allow owners to list and reveal order keys

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c38ebdcde083228ec8e15abe653a60