### PR TITLE
Allow repeated game purchases

### DIFF
--- a/backend/controllers/payment_controller.go
+++ b/backend/controllers/payment_controller.go
@@ -17,8 +17,7 @@ import (
 )
 
 var (
-	ErrNotEnoughKeys       = errors.New("not enough keys")
-	ErrUserAlreadyOwnsGame = errors.New("user already owns game")
+	ErrNotEnoughKeys = errors.New("not enough keys")
 )
 
 func baseURL(c *gin.Context) string {
@@ -201,7 +200,7 @@ func UpdatePayment(c *gin.Context) {
 		case errors.Is(err, gorm.ErrRecordNotFound):
 			c.JSON(http.StatusNotFound, gin.H{"error": "payment not found"})
 			return
-		case errors.Is(err, ErrNotEnoughKeys), errors.Is(err, ErrUserAlreadyOwnsGame):
+		case errors.Is(err, ErrNotEnoughKeys):
 			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 			return
 		default:
@@ -244,7 +243,7 @@ func ApprovePayment(c *gin.Context) {
 		case errors.Is(err, gorm.ErrRecordNotFound):
 			c.JSON(http.StatusNotFound, gin.H{"error": "payment not found"})
 			return
-		case errors.Is(err, ErrNotEnoughKeys), errors.Is(err, ErrUserAlreadyOwnsGame):
+		case errors.Is(err, ErrNotEnoughKeys):
 			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 			return
 		default:
@@ -324,9 +323,6 @@ func changePaymentStatus(paymentID uint, newStatus string, rejectReason *string)
 						GrantedAt:          time.Now(),
 					}
 					if err := tx.Create(&ug).Error; err != nil {
-						if errors.Is(err, gorm.ErrDuplicatedKey) {
-							return fmt.Errorf("%w: game %d", ErrUserAlreadyOwnsGame, item.GameID)
-						}
 						return fmt.Errorf("create user_game failed: %w", err)
 					}
 				}

--- a/backend/entity/request.go
+++ b/backend/entity/request.go
@@ -10,8 +10,8 @@ type Request struct {
 	gorm.Model
 	Reason    string    `json:"reason"`
 	Date      time.Time `json:"release_date" gorm:"autoCreateTime"`
-	UserRefer uint      `json:"user" gorm:"not null;index:idx_user_game,unique"`
-	GameRefer uint      `json:"game" gorm:"not null;index:idx_user_game,unique"`
+	UserRefer uint      `json:"user" gorm:"not null;index:idx_user_game,unique,priority:1"`
+	GameRefer uint      `json:"game" gorm:"not null;index:idx_user_game,unique,priority:2"`
 
 	User User `json:"user_obj" gorm:"foreignKey:UserRefer;references:ID"` // BelongsTo
 	Game Game `json:"game_obj" gorm:"foreignKey:GameRefer;references:ID"` // BelongsTo

--- a/backend/entity/user_game.go
+++ b/backend/entity/user_game.go
@@ -10,10 +10,10 @@ import (
 type UserGame struct {
 	gorm.Model
 
-	UserID uint  `json:"user_id" gorm:"index:idx_user_game_unique,unique"`
+	UserID uint  `json:"user_id"`
 	User   *User `gorm:"foreignKey:UserID" json:"user,omitempty"`
 
-	GameID uint  `json:"game_id" gorm:"index:idx_user_game_unique,unique"`
+	GameID uint  `json:"game_id"`
 	Game   *Game `gorm:"foreignKey:GameID" json:"game,omitempty"`
 
 	GrantedAt          time.Time `json:"granted_at"`


### PR DESCRIPTION
## Summary
- remove unique constraint from `UserGame` so users can own the same game multiple times
- simplify payment approval to always create a `UserGame` entry for each purchased key
- fix request composite index definition to avoid migration conflicts

## Testing
- `go vet ./...`
- `go test ./...`
- `go run main.go`

------
https://chatgpt.com/codex/tasks/task_e_68c394648a088322b4b165b9cdbe18f0