### PR TITLE
feat: display promotions on home banner

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,17 +1,53 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import ProductGrid from "../components/ProductGrid";
 import { useAuth } from "../context/AuthContext";
 import { Button, Space, Typography } from "antd";
+import type { Promotion } from "../interfaces/Promotion";
+import { listPromotions } from "../services/promotions";
 
 const { Title } = Typography;
+const base_url = import.meta.env.VITE_API_URL || "http://localhost:8088";
+
+const resolveImgUrl = (src?: string) => {
+  if (!src) return "";
+  if (src.startsWith("data:image/") || src.startsWith("http") || src.startsWith("blob:")) return src;
+  const clean = src.startsWith("/") ? src.slice(1) : src;
+  return `${base_url}/${clean}`;
+};
 
 const Home = () => {
   const { userId } = useAuth();
+  const [promotions, setPromotions] = useState<Promotion[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await listPromotions();
+        setPromotions(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
+
+  const promo = promotions[0];
+
   return (
     <div style={{ background: '#141414', flex: 1 , minHeight: '100vh'}}>
       <Navbar />
       <div style={{ padding: '16px' }}>
-        <div style={{ background: 'linear-gradient(90deg, #9254de 0%, #f759ab 100%)', height: 180, borderRadius: 10, marginBottom: 24, flex: 1}}></div>
+        {promo && (
+          <img
+            src={resolveImgUrl(promo.promo_image)}
+            alt={promo.title}
+            style={{ height: 180, width: '100%', objectFit: 'cover', borderRadius: 10, marginBottom: 24, cursor: 'pointer' }}
+            onClick={() => navigate(`/promotion/${promo.ID}`)}
+          />
+        )}
         <Title level={3} style={{ color: 'white' }}>Product</Title>
         <Space style={{ marginBottom: 16 }}>
           <Button type="primary" shape="round">Top</Button>


### PR DESCRIPTION
## Summary
- fetch promotions on home page and store in state
- show first promotion image as clickable banner linking to detail page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 137 problems)


------
https://chatgpt.com/codex/tasks/task_e_68c3c5b877a08329b3395cec6b714752