### PR TITLE
feat: add promotion banner component

### DIFF
--- a/frontend/src/components/PromotionBanner.tsx
+++ b/frontend/src/components/PromotionBanner.tsx
@@ -1,0 +1,76 @@
+import { Carousel } from "antd";
+import type { Promotion } from "../interfaces/Promotion";
+
+const base_url = import.meta.env.VITE_API_URL || "http://localhost:8088";
+
+const resolveImgUrl = (src?: string) => {
+  if (!src) return "";
+  if (src.startsWith("blob:")) return "";
+  if (src.startsWith("data:image/")) return src;
+  if (
+    src.startsWith("http://") ||
+    src.startsWith("https://") ||
+    src.startsWith("blob:")
+  ) {
+    return src;
+  }
+  const clean = src.startsWith("/") ? src.slice(1) : src;
+  return `${base_url}/${clean}`;
+};
+
+interface PromotionBannerProps {
+  promotions: Promotion[];
+  onClick: (id: number) => void;
+}
+
+const PromotionBanner = ({ promotions, onClick }: PromotionBannerProps) => {
+  const promotionsWithImages = promotions.filter((promo) => promo.promo_image);
+
+  if (promotionsWithImages.length === 0) return null;
+
+  if (promotionsWithImages.length > 1) {
+    return (
+      <Carousel autoplay style={{ marginBottom: 24 }}>
+        {promotionsWithImages.map((promo) => (
+          <div
+            key={promo.ID}
+            onClick={() => onClick(promo.ID)}
+            style={{ cursor: "pointer" }}
+          >
+            <img
+              src={resolveImgUrl(promo.promo_image)}
+              alt={promo.title}
+              style={{
+                height: 180,
+                width: "100%",
+                objectFit: "cover",
+                borderRadius: 10,
+              }}
+            />
+          </div>
+        ))}
+      </Carousel>
+    );
+  }
+
+  const promo = promotionsWithImages[0];
+  return (
+    <div
+      onClick={() => onClick(promo.ID)}
+      style={{ cursor: "pointer", marginBottom: 24 }}
+    >
+      <img
+        src={resolveImgUrl(promo.promo_image)}
+        alt={promo.title}
+        style={{
+          height: 180,
+          width: "100%",
+          objectFit: "cover",
+          borderRadius: 10,
+        }}
+      />
+    </div>
+  );
+};
+
+export default PromotionBanner;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,27 +3,12 @@ import { useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import ProductGrid from "../components/ProductGrid";
 import { useAuth } from "../context/AuthContext";
-import { Button, Space, Typography, Carousel } from "antd";
+import { Button, Space, Typography } from "antd";
 import type { Promotion } from "../interfaces/Promotion";
 import { listPromotions } from "../services/promotions";
+import PromotionBanner from "../components/PromotionBanner";
 
 const { Title } = Typography;
-const base_url = import.meta.env.VITE_API_URL || "http://localhost:8088";
-
-const resolveImgUrl = (src?: string) => {
-  if (!src) return "";
-  if (src.startsWith("blob:")) return "";
-  if (src.startsWith("data:image/")) return src;
-  if (
-    src.startsWith("http://") ||
-    src.startsWith("https://") ||
-    src.startsWith("blob:")
-  ) {
-    return src;
-  }
-  const clean = src.startsWith("/") ? src.slice(1) : src;
-  return `${base_url}/${clean}`;
-};
 
 const Home = () => {
   const { userId } = useAuth();
@@ -42,52 +27,14 @@ const Home = () => {
     load();
   }, []);
 
-  const promotionsWithImages = promotions.filter((promo) => promo.promo_image);
-
   return (
     <div style={{ background: '#141414', flex: 1, minHeight: '100vh' }}>
       <Navbar />
       <div style={{ padding: '16px' }}>
-        {promotionsWithImages.length > 0 && (
-          promotionsWithImages.length > 1 ? (
-            <Carousel autoplay style={{ marginBottom: 24 }}>
-              {promotionsWithImages.map((promo) => (
-                <div
-                  key={promo.ID}
-                  onClick={() => navigate(`/promotion/${promo.ID}`)}
-                  style={{ cursor: 'pointer' }}
-                >
-                  <img
-                    src={resolveImgUrl(promo.promo_image)}
-                    alt={promo.title}
-                    style={{
-                      height: 180,
-                      width: '100%',
-                      objectFit: 'cover',
-                      borderRadius: 10,
-                    }}
-                  />
-                </div>
-              ))}
-            </Carousel>
-          ) : (
-            <div
-              onClick={() => navigate(`/promotion/${promotionsWithImages[0].ID}`)}
-              style={{ cursor: 'pointer', marginBottom: 24 }}
-            >
-              <img
-                src={resolveImgUrl(promotionsWithImages[0].promo_image)}
-                alt={promotionsWithImages[0].title}
-                style={{
-                  height: 180,
-                  width: '100%',
-                  objectFit: 'cover',
-                  borderRadius: 10,
-                }}
-              />
-            </div>
-          )
-        )}
+        <PromotionBanner
+          promotions={promotions}
+          onClick={(id) => navigate(`/promotion/${id}`)}
+        />
         <Title level={3} style={{ color: 'white' }}>Product</Title>
         <Space style={{ marginBottom: 16 }}>
           <Button type="primary" shape="round">


### PR DESCRIPTION
## Summary
- extract promotion carousel into PromotionBanner component
- use PromotionBanner in Home page with click navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 131 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ca809a448329a89652fed8505c41