### PR TITLE
Remove discount and status tags from promotion detail

### DIFF
--- a/frontend/src/pages/Promotion/PromotionDetail.tsx
+++ b/frontend/src/pages/Promotion/PromotionDetail.tsx
@@ -85,15 +85,9 @@ export default function PromotionDetail() {
               {promotion.title}
             </Title>
             <div style={{ marginTop: 8 }}>
-              <Tag color="magenta" style={{ marginRight: 8 }}>
-                {promotion.discount_type === "PERCENT"
-                  ? `-${promotion.discount_value}%`
-                  : `-${promotion.discount_value}`}
-              </Tag>
               <Tag>
                 {dayjs(promotion.start_date).format("YYYY-MM-DD")} → {dayjs(promotion.end_date).format("YYYY-MM-DD")}
               </Tag>
-              <Tag color={promotion.status ? 'green' : undefined}>{promotion.status ? 'ใช้งาน' : 'ปิดใช้งาน'}</Tag>
             </div>
             {promotion.description && (
               <div style={{ color: "#ccc", marginTop: 8 }}>{promotion.description}</div>


### PR DESCRIPTION
## Summary
- Simplify promotion detail card to show only the date range tag

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `@typescript-eslint/no-explicit-any` and other lint errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d59a226483298b781982b317bb64