### PR TITLE
feat: display discounted prices in promotion details

### DIFF
--- a/frontend/src/interfaces/Game.ts
+++ b/frontend/src/interfaces/Game.ts
@@ -6,6 +6,7 @@ export interface Game {
       categories: {ID: number, title: string};
       release_date: string;
       base_price: number;
+      discounted_price?: number;
       img_src: string;
       age_rating: number;
       status: string;

--- a/frontend/src/pages/Promotion/PromotionDetail.tsx
+++ b/frontend/src/pages/Promotion/PromotionDetail.tsx
@@ -102,14 +102,40 @@ export default function PromotionDetail() {
             <List
               dataSource={games}
               locale={{ emptyText: <Text style={{ color: "#888" }}>ยังไม่มีเกม</Text> }}
-              renderItem={(g) => (
-                <List.Item actions={[<Button key="buy" onClick={() => navigate(`/game/${g.ID}`)}>ไปหน้าซื้อ</Button>]}> 
-                  <List.Item.Meta
-                    title={<Text style={{ color: "white" }}>{g.game_name}</Text>}
-                    description={<Text style={{ color: "#aaa" }}>Game ID: {g.ID}</Text>}
-                  />
-                </List.Item>
-              )}
+              renderItem={(g) => {
+                const hasDiscount =
+                  typeof g.discounted_price === "number" &&
+                  g.discounted_price > 0 &&
+                  g.discounted_price < g.base_price;
+
+                return (
+                  <List.Item
+                    actions={[
+                      <Button key="buy" onClick={() => navigate(`/game/${g.ID}`)}>
+                        ไปหน้าซื้อ
+                      </Button>,
+                    ]}
+                  >
+                    <List.Item.Meta
+                      title={<Text style={{ color: "white" }}>{g.game_name}</Text>}
+                      description={
+                        <div style={{ color: "#9254de" }}>
+                          {hasDiscount ? (
+                            <>
+                              <span style={{ textDecoration: "line-through", color: "#ccc" }}>
+                                {g.base_price}
+                              </span>
+                              <span style={{ marginLeft: 8 }}>{g.discounted_price}</span>
+                            </>
+                          ) : (
+                            g.base_price
+                          )}
+                        </div>
+                      }
+                    />
+                  </List.Item>
+                );
+              }}
             />
             <div style={{ marginTop: 12 }}>
               <Link to="/promotions">


### PR DESCRIPTION
## Summary
- support optional discounted_price field for games
- show discounted price on promotion detail page with strikethrough full price

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d6bf78448329ab31990f9c39f8b3