### PR TITLE
Use game cards in promotion detail page

### DIFF
--- a/frontend/src/components/GameCard.tsx
+++ b/frontend/src/components/GameCard.tsx
@@ -1,0 +1,45 @@
+import { Card, Button } from "antd";
+import type { Game } from "../interfaces/Game";
+
+interface GameCardProps {
+  game: Game;
+  imgSrc: string;
+  onBuy: () => void;
+}
+
+export default function GameCard({ game, imgSrc, onBuy }: GameCardProps) {
+  const hasDiscount = game.discounted_price < game.base_price;
+
+  return (
+    <Card
+      style={{ background: "#1f1f1f", color: "white", borderRadius: 10 }}
+      cover={
+        <img
+          src={imgSrc}
+          alt={game.game_name}
+          style={{ height: 150, objectFit: "cover" }}
+        />
+      }
+    >
+      <Card.Meta
+        title={<div style={{ color: "#fff" }}>{game.game_name}</div>}
+      />
+      <div style={{ marginTop: 10, color: "#9254de" }}>
+        {hasDiscount ? (
+          <>
+            <span style={{ textDecoration: "line-through", color: "#ccc" }}>
+              {game.base_price}
+            </span>
+            <span style={{ marginLeft: 8 }}>{game.discounted_price}</span>
+          </>
+        ) : (
+          game.base_price
+        )}
+      </div>
+      <Button block style={{ marginTop: 10 }} onClick={onBuy}>
+        ไปหน้าซื้อ
+      </Button>
+    </Card>
+  );
+}
+

--- a/frontend/src/pages/Promotion/PromotionDetail.tsx
+++ b/frontend/src/pages/Promotion/PromotionDetail.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
-import { Layout, Typography, Card, Tag, List, Button, Empty } from "antd";
+import { Layout, Typography, Card, Tag, Button, Empty, Row, Col } from "antd";
 import Sidebar from "../../components/Sidebar";
+import GameCard from "../../components/GameCard";
 import type { Promotion } from "../../interfaces/Promotion";
 import type { Game } from "../../interfaces/Game";
 import { getPromotion } from "../../services/promotions";
@@ -124,41 +125,21 @@ export default function PromotionDetail() {
             bodyStyle={{ background: "#141414" }}
             style={{ background: "#1f1f1f", color: "white", borderRadius: 10 }}
           >
-            <List
-              dataSource={games}
-              locale={{ emptyText: <Text style={{ color: "#888" }}>ยังไม่มีเกม</Text> }}
-              renderItem={(g) => {
-                const hasDiscount = g.discounted_price < g.base_price;
-
-                return (
-                  <List.Item
-                    actions={[
-                      <Button key="buy" onClick={() => navigate(`/game/${g.ID}`)}>
-                        ไปหน้าซื้อ
-                      </Button>,
-                    ]}
-                  >
-                    <List.Item.Meta
-                      title={<Text style={{ color: "white" }}>{g.game_name}</Text>}
-                      description={
-                        <div style={{ color: "#9254de" }}>
-                          {hasDiscount ? (
-                            <>
-                              <span style={{ textDecoration: "line-through", color: "#ccc" }}>
-                                {g.base_price}
-                              </span>
-                              <span style={{ marginLeft: 8 }}>{g.discounted_price}</span>
-                            </>
-                          ) : (
-                            g.base_price
-                          )}
-                        </div>
-                      }
+            {games.length > 0 ? (
+              <Row gutter={[16, 16]}>
+                {games.map((g) => (
+                  <Col key={g.ID} xs={24} sm={12} md={8} lg={6}>
+                    <GameCard
+                      game={g}
+                      imgSrc={resolveImgUrl(g.img_src)}
+                      onBuy={() => navigate(`/game/${g.ID}`)}
                     />
-                  </List.Item>
-                );
-              }}
-            />
+                  </Col>
+                ))}
+              </Row>
+            ) : (
+              <Text style={{ color: "#888" }}>ยังไม่มีเกม</Text>
+            )}
             <div style={{ marginTop: 12 }}>
               <Link to="/promotions">
                 <Button>ย้อนกลับ</Button>


### PR DESCRIPTION
## Summary
- add reusable `GameCard` component based on home product card
- render promotion games in a `<Row><Col><Card>` grid with images via `resolveImgUrl`
- keep navigation on "ไปหน้าซื้อ" buttons

## Testing
- `npm run lint` *(fails: many pre-existing ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e07ec67c83298630e592d8d0bfb4