### PR TITLE
Use API game list directly in promotion detail

### DIFF
--- a/frontend/src/pages/Promotion/PromotionDetail.tsx
+++ b/frontend/src/pages/Promotion/PromotionDetail.tsx
@@ -57,16 +57,8 @@ export default function PromotionDetail() {
         const data = await getPromotion(Number(id), true);
         setPromotion(data);
         if (data.games) {
-          const related = data.games.filter((g: any) => {
-            if (Array.isArray(g.promotion_games)) {
-              return g.promotion_games.some(
-                (pg: any) => pg.promotion_id === data.ID,
-              );
-            }
-            return g.promotion_id === data.ID;
-          });
           setGames(
-            related.map((g: any) => ({
+            data.games.map((g: any) => ({
               ...g,
               discounted_price: applyDiscount(
                 g.base_price,


### PR DESCRIPTION
## Summary
- Use game list from API directly instead of filtering
- Compute discounted prices for each game returned in promotion detail

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any & other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e51fd344832989a4d81456a7f7eb