### PR TITLE
Expose review stats and show average rating

### DIFF
--- a/frontend/src/components/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection.tsx
@@ -17,6 +17,7 @@ export type ReviewSectionProps = {
   gameId: number;
   allowCreate?: boolean;
   className?: string;
+  onStatsChange?: (stats: { count: number; average: number }) => void;
 };
 
 /** ให้ rating เป็นจำนวนเต็ม 1–5 */
@@ -41,7 +42,12 @@ async function fetchUsernameById(id: number) {
   }
 }
 
-const ReviewSection: React.FC<ReviewSectionProps> = ({ gameId, allowCreate = true, className }) => {
+const ReviewSection: React.FC<ReviewSectionProps> = ({
+  gameId,
+  allowCreate = true,
+  className,
+  onStatsChange,
+}) => {
   const { id: authId, token } = useAuth();
   const userId = authId ? Number(authId) : undefined;
 
@@ -50,6 +56,17 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({ gameId, allowCreate = tru
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<ReviewItem | null>(null);
   const [form] = Form.useForm<{ title?: string; content: string; rating: number }>();
+
+  const avgRating = useMemo(
+    () =>
+      items.length
+        ? items.reduce((s, r) => s + clampIntRating(r.rating), 0) / items.length
+        : 0,
+    [items]
+  );
+  useEffect(() => {
+    onStatsChange?.({ count: items.length, average: avgRating });
+  }, [items, avgRating, onStatsChange]);
 
   /** ------- โหลดรีวิว + เติมชื่อผู้ใช้ -------- */
   const load = async () => {

--- a/frontend/src/pages/Game/GameDetail.tsx
+++ b/frontend/src/pages/Game/GameDetail.tsx
@@ -13,6 +13,7 @@ import {
   Divider,
   Space,
   Tooltip,
+  Rate,
   message,
 } from "antd";
 import {
@@ -56,6 +57,7 @@ const GameDetail: React.FC = () => {
   const [mods, setMods] = React.useState<Mod[]>([]);
   const [minSpec, setMinSpec] = React.useState<MinimumSpec | null>(null);
   const [msg, ctx] = message.useMessage();
+  const [avgRating, setAvgRating] = React.useState(0);
 
   // contexts
   const { addItem } = useCart();
@@ -511,11 +513,27 @@ const GameDetail: React.FC = () => {
       </Card>
 
       <Card
-        title={<Space><StarFilled /><span>User Reviews</span></Space>}
+        title={
+          <Space>
+            <StarFilled />
+            <span>User Reviews</span>
+            {avgRating > 0 && (
+              <Space size={4} style={{ color: "#fadb14" }}>
+                <Rate disabled allowHalf value={avgRating} />
+                <span>{avgRating.toFixed(1)}</span>
+              </Space>
+            )}
+          </Space>
+        }
         style={{ marginTop: 16, background: "#12181f", borderColor: "#23313a" }}
         headStyle={{ color: "#fff" }}
       >
-        <ReviewSection gameId={gid} allowCreate className="mt-4" />
+        <ReviewSection
+          gameId={gid}
+          allowCreate
+          className="mt-4"
+          onStatsChange={(s) => setAvgRating(s.average)}
+        />
       </Card>
     </Content>
 


### PR DESCRIPTION
## Summary
- expose review statistics via `onStatsChange` in `ReviewSection`
- display average user rating in `GameDetail`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c40a95b8648329ae1e75674a7da223