### PR TITLE
feat: prioritize user review

### DIFF
--- a/frontend/src/components/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection.tsx
@@ -84,6 +84,15 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
       // sort ล่าสุดขึ้นก่อน
       normalized.sort((a, b) => (b.UpdatedAt || "").localeCompare(a.UpdatedAt || ""));
 
+      // หากมีรีวิวของผู้ใช้เอง ให้ย้ายขึ้นมาไว้ด้านบนสุด
+      if (typeof userId === "number") {
+        const myIndex = normalized.findIndex((r) => r.user_id === userId);
+        if (myIndex >= 0) {
+          const [mine] = normalized.splice(myIndex, 1);
+          normalized.unshift(mine);
+        }
+      }
+
       // หา user_id ที่ยังไม่มี username แล้วดึงชื่อมาเติม
       const missingIds = Array.from(
         new Set(
@@ -168,7 +177,19 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
           },
           token || undefined
         );
-        setItems((prev) => prev.map((it) => (it.ID === editing.ID ? { ...it, ...saved, rating } : it)));
+        setItems((prev) => {
+          const updated = prev.map((it) =>
+            it.ID === editing.ID ? { ...it, ...saved, rating } : it
+          );
+          if (typeof userId === "number") {
+            const myIndex = updated.findIndex((r) => r.user_id === userId);
+            if (myIndex >= 0) {
+              const [mine] = updated.splice(myIndex, 1);
+              updated.unshift(mine);
+            }
+          }
+          return updated;
+        });
         message.success("อัปเดตรีวิวแล้ว");
       } else {
         if (!userId) {


### PR DESCRIPTION
## Summary
- ensure signed-in user's review moves to top of list on load
- keep edited review at top after updating

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68c40da7152c8329b36d142838d9bc9d