### PR TITLE
Make GameCard clickable for navigation

### DIFF
--- a/frontend/src/components/GameCard.tsx
+++ b/frontend/src/components/GameCard.tsx
@@ -1,18 +1,24 @@
-import { Card, Button } from "antd";
+import { Card } from "antd";
 import type { Game } from "../interfaces/Game";
 
 interface GameCardProps {
   game: Game;
   imgSrc: string;
-  onBuy: () => void;
+  onClick?: () => void;
 }
 
-export default function GameCard({ game, imgSrc, onBuy }: GameCardProps) {
+export default function GameCard({ game, imgSrc, onClick }: GameCardProps) {
   const hasDiscount = game.discounted_price < game.base_price;
 
   return (
     <Card
-      style={{ background: "#1f1f1f", color: "white", borderRadius: 10 }}
+      hoverable
+      style={{
+        background: "#1f1f1f",
+        color: "white",
+        borderRadius: 10,
+        cursor: "pointer",
+      }}
       cover={
         <img
           src={imgSrc}
@@ -20,6 +26,7 @@ export default function GameCard({ game, imgSrc, onBuy }: GameCardProps) {
           style={{ height: 150, objectFit: "cover" }}
         />
       }
+      onClick={onClick}
     >
       <Card.Meta
         title={<div style={{ color: "#fff" }}>{game.game_name}</div>}
@@ -36,9 +43,6 @@ export default function GameCard({ game, imgSrc, onBuy }: GameCardProps) {
           game.base_price
         )}
       </div>
-      <Button block style={{ marginTop: 10 }} onClick={onBuy}>
-        ไปหน้าซื้อ
-      </Button>
     </Card>
   );
 }

--- a/frontend/src/pages/Promotion/PromotionDetail.tsx
+++ b/frontend/src/pages/Promotion/PromotionDetail.tsx
@@ -58,7 +58,7 @@ export default function PromotionDetail() {
         setPromotion(data);
         if (data.games) {
           setGames(
-            data.games.map((g: any) => ({
+            data.games.map((g: Game) => ({
               ...g,
               discounted_price: applyDiscount(
                 g.base_price,
@@ -132,7 +132,7 @@ export default function PromotionDetail() {
                     <GameCard
                       game={g}
                       imgSrc={resolveImgUrl(g.img_src)}
-                      onBuy={() => navigate(`/game/${g.ID}`)}
+                      onClick={() => navigate(`/game/${g.ID}`)}
                     />
                   </Col>
                 ))}


### PR DESCRIPTION
## Summary
- make `GameCard` clickable and hoverable by replacing onBuy with onClick handler
- update promotion detail page to navigate on card click and type game mapping

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any & other lint errors)*
- `npx eslint src/components/GameCard.tsx src/pages/Promotion/PromotionDetail.tsx && echo "ESLint passed"`
- `npm run build` *(fails: Merge conflict marker in src/routes/text.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c413ba4a2483299719846adfccbb85