### PR TITLE
Navigate to payment after purchase

### DIFF
--- a/frontend/src/pages/Game/GameDetail.tsx
+++ b/frontend/src/pages/Game/GameDetail.tsx
@@ -190,11 +190,11 @@ const GameDetail: React.FC = () => {
         addItem({ id: Number(gameId), title, price, quantity: 1 });
         msg.success(`เพิ่ม ${title} ลงตะกร้าแล้ว`);
       }
-    
-    navigate("/category/Payment");
     } catch (err) {
       console.error("purchase error:", err);
       msg.error("ไม่สามารถทำรายการได้");
+    } finally {
+      navigate("/category/Payment");
     }
   };
 


### PR DESCRIPTION
## Summary
- Always redirect to `/category/Payment` after a game purchase
- Use a `finally` block so the redirect occurs for both logged-in and guest flows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many TypeScript lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c424f3871c8329adb4efb3654bd5f9