### PR TITLE
Ensure cart item added before payment navigation

### DIFF
--- a/frontend/src/pages/Game/GameDetail.tsx
+++ b/frontend/src/pages/Game/GameDetail.tsx
@@ -187,13 +187,13 @@ const GameDetail: React.FC = () => {
         msg.success("สร้างออเดอร์เรียบร้อย");
       } else {
         // โฟลว์ตะกร้า local
-        addItem({ id: Number(gameId), title, price, quantity: 1 });
         msg.success(`เพิ่ม ${title} ลงตะกร้าแล้ว`);
       }
     } catch (err) {
       console.error("purchase error:", err);
       msg.error("ไม่สามารถทำรายการได้");
     } finally {
+      addItem({ id: Number(gameId), title, price, quantity: 1 });
       navigate("/category/Payment");
     }
   };


### PR DESCRIPTION
## Summary
- always add selected game to cart before navigating to Payment
- use current game's id, title, and price in cart item

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any. Specify a different type)


------
https://chatgpt.com/codex/tasks/task_e_68c4276ef2f483298515126b751b3638