### PR TITLE
Refactor promotion pricing and shared discount logic

### DIFF
--- a/backend/controllers/games.go
+++ b/backend/controllers/games.go
@@ -6,6 +6,7 @@ import (
 
 	"example.com/sa-gameshop/configs"
 	"example.com/sa-gameshop/entity"
+	"example.com/sa-gameshop/services"
 	"github.com/gin-gonic/gin"
 )
 
@@ -107,7 +108,7 @@ func FindGames(c *gin.Context) {
 	for _, g := range games {
 		discounted := float64(g.BasePrice)
 		for _, p := range g.Promotions {
-			if price := applyDiscount(float64(g.BasePrice), p.DiscountType, p.DiscountValue); price < discounted {
+			if price := services.ApplyDiscount(float64(g.BasePrice), p.DiscountType, p.DiscountValue); price < discounted {
 				discounted = price
 			}
 		}

--- a/backend/services/discount.go
+++ b/backend/services/discount.go
@@ -1,0 +1,22 @@
+package services
+
+import "example.com/sa-gameshop/entity"
+
+// ApplyDiscount applies a discount described by type and value to the given price.
+// It returns the price after discount, ensuring it doesn't go below zero.
+func ApplyDiscount(price float64, t entity.DiscountType, v int) float64 {
+	if v <= 0 {
+		return price
+	}
+	switch t {
+	case entity.DiscountPercent:
+		return price * (1.0 - float64(v)/100.0)
+	case entity.DiscountAmount:
+		if price < float64(v) {
+			return 0
+		}
+		return price - float64(v)
+	default:
+		return price
+	}
+}

--- a/backend/services/pricing.go
+++ b/backend/services/pricing.go
@@ -20,61 +20,27 @@ func GetDiscountedPriceForGame(db *gorm.DB, gameID uint, now time.Time) (float64
 	}
 	base := float64(g.BasePrice)
 
-	// พยายามอ่านโปรโมชันผ่าน raw SQL แบบยืดหยุ่น (รองรับชื่อคอลัมน์ที่ต่างกันได้บ้าง)
+	// อ่านโปรโมชันที่กำลังใช้งานอยู่
 	type promoRow struct {
-		Percent *float64
-		Amount  *float64
-		Price   *float64
+		DiscountType  entity.DiscountType
+		DiscountValue int
 	}
-
-	var r promoRow
-	// attempt #1: promotions + promotion_games (คอลัมน์ชื่อทั่วไป)
-	err := db.Raw(`
-		SELECT
-			CAST(p.discount_percent AS REAL) AS percent,
-			CAST(p.discount_amount  AS REAL) AS amount,
-			CAST(p.special_price    AS REAL) AS price
-		FROM promotions p
-		JOIN promotion_games pg ON pg.promotion_id = p.id
-		WHERE pg.game_id = ?
-		  AND (p.start_at IS NULL OR p.start_at <= ?)
-		  AND (p.end_at   IS NULL OR p.end_at   >= ?)
-		  AND (p.is_active IS NULL OR p.is_active = 1)
-		ORDER BY p.priority DESC, p.id DESC
-		LIMIT 1
-	`, gameID, now, now).Scan(&r).Error
-	if err != nil {
-		// attempt #2: บางโปรเจ็กต์ใช้ชื่อคอลัมน์อีกแบบ
-		_ = db.Raw(`
-			SELECT
-				CAST(p.percent     AS REAL) AS percent,
-				CAST(p.amount      AS REAL) AS amount,
-				CAST(p.sale_price  AS REAL) AS price
-			FROM promotions p
-			JOIN promotion_games pg ON pg.promotion_id = p.id
-			WHERE pg.game_id = ?
-			  AND (p.starts_at IS NULL OR p.starts_at <= ?)
-			  AND (p.ends_at   IS NULL OR p.ends_at   >= ?)
-			  AND (p.active    IS NULL OR p.active = 1)
-			ORDER BY p.id DESC
-			LIMIT 1
-		`, gameID, now, now).Scan(&r).Error
+	var promos []promoRow
+	if err := db.Raw(`
+                SELECT p.discount_type, p.discount_value
+                FROM promotions p
+                JOIN promotion_games pg ON pg.promotion_id = p.id
+                WHERE pg.game_id = ? AND p.status = 1
+                      AND p.start_date <= ? AND p.end_date >= ?
+        `, gameID, now, now).Scan(&promos).Error; err != nil {
+		return 0, err
 	}
 
 	// เลือกวิธีลดที่ให้ "ราคาต่ำสุด" อย่างปลอดภัย
 	price := base
-	if r.Price != nil && *r.Price > 0 && *r.Price < price {
-		price = *r.Price
-	}
-	if r.Percent != nil && *r.Percent > 0 {
-		p := *r.Percent
-		price = base * (100.0 - p) / 100.0
-	}
-	if r.Amount != nil && *r.Amount > 0 {
-		if base-*r.Amount < price {
-			price = base - *r.Amount
-		} else if price-*r.Amount < price {
-			price = price - *r.Amount
+	for _, p := range promos {
+		if discounted := ApplyDiscount(base, p.DiscountType, p.DiscountValue); discounted < price {
+			price = discounted
 		}
 	}
 


### PR DESCRIPTION
## Summary
- replace raw SQL discount search with query for active promotions and compute lowest discounted price
- move applyDiscount helper into services package for reuse
- update game controller to use new ApplyDiscount

## Testing
- `go vet ./services`
- `go test ./services -run Test -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68c44b0062a08322a684da63e82240cd