### PR TITLE
Handle unauthorized review creation errors

### DIFF
--- a/frontend/src/components/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection.tsx
@@ -196,25 +196,34 @@ const ReviewSection: React.FC<ReviewSectionProps> = ({
           message.info("กรุณาเข้าสู่ระบบ");
           return;
         }
-        const created = await ReviewsAPI.createJson(
-          {
-            game_id: gameId,
-            user_id: userId,
-            review_title: values.title,
-            review_text: values.content,
-            rating,
-          },
-          token || undefined
-        );
+        try {
+          const created = await ReviewsAPI.createJson(
+            {
+              game_id: gameId,
+              user_id: userId,
+              review_title: values.title,
+              review_text: values.content,
+              rating,
+            },
+            token || undefined
+          );
 
-        // เติมชื่อทันทีหลังสร้าง (ถ้าคุณมีชื่อใน auth context ใส่แทน created.username ได้)
-        const createdWithName = { ...created } as ReviewItem;
-        if (!createdWithName.username) {
-          createdWithName.username = await fetchUsernameById(userId);
+          // เติมชื่อทันทีหลังสร้าง (ถ้าคุณมีชื่อใน auth context ใส่แทน created.username ได้)
+          const createdWithName = { ...created } as ReviewItem;
+          if (!createdWithName.username) {
+            createdWithName.username = await fetchUsernameById(userId);
+          }
+
+          setItems((prev) => [createdWithName, ...prev]);
+          message.success("สร้างรีวิวแล้ว");
+        } catch (err) {
+          if (axios.isAxiosError(err) && err.response?.status === 403) {
+            message.error("ยังไม่ได้เป็นเจ้าของเกม");
+          } else {
+            message.error("สร้างรีวิวไม่สำเร็จ");
+          }
+          return;
         }
-
-        setItems((prev) => [createdWithName, ...prev]);
-        message.success("สร้างรีวิวแล้ว");
       }
 
       setShowForm(false);


### PR DESCRIPTION
## Summary
- Wrap `ReviewsAPI.createJson` in try/catch
- Show specific error when user is not game owner and generic error otherwise

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in many files)*

------
https://chatgpt.com/codex/tasks/task_e_68c52a617ad08329892a33e2c815604d