### PR TITLE
Improve mod rating and show game rating

### DIFF
--- a/frontend/src/pages/Game/GameDetail.tsx
+++ b/frontend/src/pages/Game/GameDetail.tsx
@@ -262,6 +262,12 @@ const GameDetail: React.FC = () => {
             <Title level={2} style={{ color: "#fff", margin: 0 }}>
               {title}
             </Title>
+            <div style={{ margin: "4px 0 12px" }}>
+              <Space size={4}>
+                <Rate disabled allowHalf value={avgRating} />
+                <span style={{ color: "#fadb14" }}>{avgRating.toFixed(1)}</span>
+              </Space>
+            </div>
             <div style={{ margin: "8px 0 12px" }}>
               <Space size={[6, 6]} wrap>
                 {tags.slice(0, 6).map((t) => (


### PR DESCRIPTION
## Summary
- prevent comments from affecting mod ratings by updating existing entries and normalizing data
- display comment timestamps and show average rating in game detail header

## Testing
- `npm --prefix frontend run lint` *(fails: Unexpected any. Specify a different type)*
- `go test ./...` *(no output, command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c53f6b1ff0832a93507da1c9edda41