### PR TITLE
feat: add dynamic permission middleware

### DIFF
--- a/backend/controllers/me.go
+++ b/backend/controllers/me.go
@@ -1,0 +1,35 @@
+package controllers
+
+import (
+	"net/http"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+	"github.com/gin-gonic/gin"
+)
+
+// GetMyPermissions returns current user's roles and permissions.
+func GetMyPermissions(c *gin.Context) {
+	uidAny, _ := c.Get("userID")
+	uid, _ := uidAny.(uint)
+
+	var user entity.User
+	if err := configs.DB().Preload("Role").Select("id, role_id").First(&user, uid).Error; err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "user not found"})
+		return
+	}
+
+	roles := []string{}
+	if user.Role.ID != 0 {
+		roles = append(roles, user.Role.Title)
+	}
+
+	var perms []string
+	configs.DB().Model(&entity.Permission{}).
+		Select("permissions.key").
+		Joins("JOIN role_permissions rp ON rp.permission_id = permissions.id").
+		Where("rp.role_id = ?", user.RoleID).
+		Pluck("permissions.key", &perms)
+
+	c.JSON(http.StatusOK, gin.H{"roles": roles, "perms": perms})
+}

--- a/backend/middlewares/auth.go
+++ b/backend/middlewares/auth.go
@@ -53,7 +53,16 @@ func AuthRequired() gin.HandlerFunc {
 			return
 		}
 		c.Set("userID", uid)
-		c.Set("roleID", claims.RoleID)
+		roleID := claims.RoleID
+		if roleID == 0 {
+			var u entity.User
+			if err := configs.DB().Select("role_id").First(&u, uid).Error; err == nil {
+				roleID = u.RoleID
+			}
+		}
+		if roleID > 0 {
+			c.Set("roleID", roleID)
+		}
 		c.Next()
 	}
 }

--- a/backend/middlewares/perm.go
+++ b/backend/middlewares/perm.go
@@ -1,0 +1,78 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+	"github.com/gin-gonic/gin"
+)
+
+// RequirePerm checks that current user's role has at least one of the given permissions.
+// It reads userID and roleID from context (set by AuthRequired). If roleID is missing
+// it will fetch from the database. Permissions are looked up fresh from DB each request
+// to ensure changes take effect immediately.
+func RequirePerm(perms ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		uidAny, ok := c.Get("userID")
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "permission denied"})
+			return
+		}
+
+		roleID := uint(0)
+		if v, ok := c.Get("roleID"); ok {
+			switch x := v.(type) {
+			case uint:
+				roleID = x
+			case *uint:
+				if x != nil {
+					roleID = *x
+				}
+			}
+		}
+		if roleID == 0 {
+			if uid, ok := uidAny.(uint); ok {
+				var u entity.User
+				if err := configs.DB().Select("role_id").First(&u, uid).Error; err == nil {
+					roleID = u.RoleID
+					c.Set("roleID", roleID)
+				}
+			}
+		}
+
+		if roleID == 0 {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "permission denied"})
+			return
+		}
+
+		var keys []string
+		configs.DB().Model(&entity.Permission{}).
+			Select("permissions.key").
+			Joins("JOIN role_permissions rp ON rp.permission_id = permissions.id").
+			Where("rp.role_id = ?", roleID).
+			Pluck("permissions.key", &keys)
+
+		allowed := false
+		permSet := map[string]bool{}
+		for _, k := range keys {
+			permSet[k] = true
+			if k == "*" {
+				allowed = true
+			}
+		}
+		if !allowed {
+			for _, need := range perms {
+				if permSet[need] {
+					allowed = true
+					break
+				}
+			}
+		}
+		if !allowed {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "permission denied"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/frontend/src/components/Require.tsx
+++ b/frontend/src/components/Require.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export const RequireAuth = ({ children }: { children: ReactNode }) => {
+  const { id } = useAuth();
+  const loc = useLocation();
+  if (!id) {
+    return <Navigate to={`/login?next=${encodeURIComponent(loc.pathname + loc.search)}`} replace />;
+  }
+  return <>{children}</>;
+};
+
+export const RequirePerm = ({ need, children }: { need: string | string[]; children: ReactNode }) => {
+  const { perms } = useAuth();
+  const needs = Array.isArray(need) ? need : [need];
+  const ok = needs.some((p) => perms.includes(p));
+  if (!ok) {
+    return <Navigate to="/" replace />;
+  }
+  return <>{children}</>;
+};
+

--- a/frontend/src/routes/text.tsx
+++ b/frontend/src/routes/text.tsx
@@ -2,6 +2,7 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
 
 import Sidebar from "../components/Sidebar";
+import { RequireAuth, RequirePerm } from "../components/Require";
 
 // pages
 import Home from "../pages/Home";
@@ -71,7 +72,13 @@ const router = createBrowserRouter([
         path: "category",
         children: [
           { path: "Community", element: <CommunityPage /> },
-          { path: "Payment", element: <PaymentPage /> },
+          { path: "Payment", element: (
+            <RequireAuth>
+              <RequirePerm need={["order:create", "payment:create"]}>
+                <PaymentPage />
+              </RequirePerm>
+            </RequireAuth>
+          ) },
         ],
       },
 
@@ -80,7 +87,13 @@ const router = createBrowserRouter([
       { path: "workshop/:id", element: <WorkshopDetail /> },
       { path: "mod/:id", element: <ModDetail /> },
       // ชี้หน้าอัปโหลดให้เป็นเส้นทางย่อยของ Workshop
-      { path: "workshop/upload", element: <Workshop /> },
+      { path: "workshop/upload", element: (
+        <RequireAuth>
+          <RequirePerm need="workshop:mod:create">
+            <Workshop />
+          </RequirePerm>
+        </RequireAuth>
+      ) },
       
        { path: "game/:id", element: <GameDetail /> },
 
@@ -108,20 +121,42 @@ const router = createBrowserRouter([
       {
         path: "Admin/Page",
         element: (
-          <AdminPage
-            refunds={refunds}
-            setRefunds={() => { }}
-            addNotification={addNotification}
-            addRefundUpdate={addRefundUpdate}
-          />
+          <RequireAuth>
+            <RequirePerm need="admin:panel">
+              <AdminPage
+                refunds={refunds}
+                setRefunds={() => { }}
+                addNotification={addNotification}
+                addRefundUpdate={addRefundUpdate}
+              />
+            </RequirePerm>
+          </RequireAuth>
         ),
       },
-      { path: "Admin/PaymentReviewPage", element: <AdminPaymentReviewPage /> },
+      { path: "Admin/PaymentReviewPage", element: (
+        <RequireAuth>
+          <RequirePerm need="admin:panel">
+            <AdminPaymentReviewPage />
+          </RequirePerm>
+        </RequireAuth>
+      ) },
 
-      { path: "Admin/RolePage", element: <RoleManagement /> },
+      { path: "Admin/RolePage", element: (
+        <RequireAuth>
+          <RequirePerm need="admin:panel">
+            <RoleManagement />
+          </RequirePerm>
+        </RequireAuth>
+      ) },
 
       // ✅ เพิ่มเส้นทางหน้ารายการที่แก้ไขแล้ว (ตรงกับปุ่ม navigate("/Admin/Resolved"))
-      { path: "Admin/Resolved", element: <ResolvedReportsPage /> },
+      { path: "Admin/Resolved", element: (
+        <RequireAuth>
+          <RequirePerm need="admin:panel">
+            <ResolvedReportsPage />
+          </RequirePerm>
+        </RequireAuth>
+      ) },
 
       // === ✅ สถานะคำสั่งซื้อ (เส้นทางที่ต้องการ)
       { path: "orders-status", element: <OrdersStatusPage /> },


### PR DESCRIPTION
## Summary
- seed application permissions and assign to roles
- add RequirePerm middleware for dynamic DB-backed permission checks
- expose /me/permissions and enforce permissions on protected routes
- store roles/permissions on frontend and guard routes via RequireAuth/RequirePerm

## Testing
- `go test ./...` *(hangs, no output)*
- `npx prettier -w frontend/src/context/AuthContext.tsx frontend/src/components/Require.tsx frontend/src/routes/text.tsx` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c55ddcfb6c832aba456ddfa320797e