### PR TITLE
Add autocomplete game search in navbar

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -5,7 +5,7 @@ import {
   DollarCircleOutlined,
 } from "@ant-design/icons";
 import { useState, useMemo } from "react";
-import { Input, Avatar, Space, Button, message } from "antd";
+import { AutoComplete, Input, Avatar, Space, Button, message } from "antd";
 import { Link, useNavigate } from "react-router-dom";
 import { listGames } from "../services/game";
 
@@ -16,29 +16,40 @@ import NotificationBell from "../components/NotificationsBell";
 const Navbar = () => {
   const [openAuth, setOpenAuth] = useState(false);
   const [searchText, setSearchText] = useState("");
+  const [options, setOptions] = useState<{ value: string; label: JSX.Element }[]>([]);
   const navigate = useNavigate();
   const { token, username, logout, id: userId } = useAuth();
 
   // ถ้าอยากใช้เป็น value ที่โชว์ตรง avatar
   const avatarText = useMemo(() => (username ? username[0]?.toUpperCase() : "U"), [username]);
 
-  const handleSearch = async () => {
-    const text = searchText.trim().toLowerCase();
-    if (!text) return;
+  const handleSearch = async (value: string) => {
+    setSearchText(value);
+    const text = value.trim().toLowerCase();
+    if (!text) {
+      setOptions([]);
+      return;
+    }
     try {
       const games = await listGames();
-      const matched = games.find((g) =>
+      const filtered = games.filter((g) =>
         g.game_name?.toLowerCase().includes(text)
       );
-      if (matched) {
-        navigate(`/game/${matched.ID}`);
-        setSearchText("");
-      } else {
-        message.error("Game not found");
-      }
+      setOptions(
+        filtered.map((g) => ({
+          value: String(g.ID),
+          label: <span>{g.game_name}</span>,
+        }))
+      );
     } catch {
       message.error("Search failed");
     }
+  };
+
+  const handleSelect = (gameId: string) => {
+    navigate(`/game/${gameId}`);
+    setSearchText("");
+    setOptions([]);
   };
 
   return (
@@ -54,20 +65,25 @@ const Navbar = () => {
       }}
     >
       {/* Search */}
-      <Input.Search
-        prefix={<SearchOutlined />}
-        placeholder="Search"
-        value={searchText}
-        onChange={(e) => setSearchText(e.target.value)}
+      <AutoComplete
+        options={options}
         onSearch={handleSearch}
+        onSelect={handleSelect}
         style={{
           width: "52%",
           borderRadius: 8,
           background: "#2f2f2f",
           color: "white",
         }}
-        allowClear
-      />
+      >
+        <Input
+          prefix={<SearchOutlined />}
+          placeholder="Search games..."
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          allowClear
+        />
+      </AutoComplete>
 
       {/* Icons + Auth */}
       <Space size="large" align="center">


### PR DESCRIPTION
## Summary
- integrate antd AutoComplete into navbar for game search
- fetch games and show filtered options by name
- navigate to selected game and reset search input

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint reported 233 errors)


------
https://chatgpt.com/codex/tasks/task_e_68c575e69df48329ac1af0dd051f3e3a