### PR TITLE
Configure CORS origin and frontend API URL

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -205,14 +205,14 @@ func main() {
 	}
 
 	// 6) Run server
-	r.Run("localhost:" + PORT)
+	r.Run("0.0.0.0:" + PORT)
 }
 
 // ---------------------- Middlewares ----------------------
 
 func CORSMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		c.Writer.Header().Set("Access-Control-Allow-Origin", "http://localhost:5173")
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 		c.Writer.Header().Set("Access-Control-Allow-Headers",
 			"Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With, X-User-ID")

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,3 @@
+VITE_API_URL=http://localhost:8088
 VITE_API_BASE_URL=http://localhost:8088
 VITE_DEV_USER_ID=1


### PR DESCRIPTION
## Summary
- Serve backend on all interfaces and restrict CORS to `http://localhost:5173`
- Specify `VITE_API_URL` for frontend to hit backend API

## Testing
- `go build ./...`
- `npm run lint` *(fails: Unexpected any. Specify a different type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c5784ae8ec8329ae86c6db81b07875