### PR TITLE
Implement admin permission model and guards

### DIFF
--- a/backend/controllers/me.go
+++ b/backend/controllers/me.go
@@ -1,0 +1,32 @@
+package controllers
+
+import (
+	"net/http"
+
+	"example.com/sa-gameshop/configs"
+	"example.com/sa-gameshop/entity"
+	"github.com/gin-gonic/gin"
+)
+
+// GET /me/permissions
+func GetMyPermissions(c *gin.Context) {
+	uidAny, _ := c.Get("userID")
+	uid, _ := uidAny.(uint)
+	var u entity.User
+	db := configs.DB()
+	if err := db.Preload("Role").First(&u, uid).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "user not found"})
+		return
+	}
+	var perms []string
+	db.Table("permissions").
+		Select("permissions.key").
+		Joins("JOIN role_permissions rp ON rp.permission_id = permissions.id").
+		Where("rp.role_id = ?", u.RoleID).
+		Pluck("permissions.key", &perms)
+	roles := []string{}
+	if u.Role.ID != 0 {
+		roles = append(roles, u.Role.Title)
+	}
+	c.JSON(http.StatusOK, gin.H{"roles": roles, "perms": perms})
+}

--- a/backend/middlewares/auth.go
+++ b/backend/middlewares/auth.go
@@ -77,3 +77,54 @@ func AdminOnly() gin.HandlerFunc {
 		c.Next()
 	}
 }
+
+// hasPerm คืน true หาก role นั้นมีสิทธิ need หรือ admin:all
+func hasPerm(perms map[string]struct{}, need string) bool {
+	if _, ok := perms["admin:all"]; ok {
+		return true
+	}
+	_, ok := perms[need]
+	return ok
+}
+
+// loadPerms: โหลดสิทธิทั้งหมดของ role จาก role_permissions → permissions
+func loadPerms(roleID uint) map[string]struct{} {
+	out := make(map[string]struct{})
+	if roleID == 0 {
+		return out
+	}
+	var keys []string
+	configs.DB().Table("permissions").
+		Select("permissions.key").
+		Joins("JOIN role_permissions rp ON rp.permission_id = permissions.id").
+		Where("rp.role_id = ?", roleID).
+		Pluck("permissions.key", &keys)
+	for _, k := range keys {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+// RequireAdminPerm ตรวจทั้ง admin:panel และ need (หรือ admin:all)
+func RequireAdminPerm(need string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		uidAny, _ := c.Get("userID")
+		roleIDAny, _ := c.Get("roleID")
+		roleID, _ := roleIDAny.(uint)
+		if roleID == 0 {
+			if uid, ok := uidAny.(uint); ok && uid > 0 {
+				var u entity.User
+				if err := configs.DB().Select("role_id").First(&u, uid).Error; err == nil {
+					roleID = u.RoleID
+					c.Set("roleID", roleID)
+				}
+			}
+		}
+		perms := loadPerms(roleID)
+		if !hasPerm(perms, "admin:panel") || !hasPerm(perms, need) {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,0 +1,13 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+import type { ReactNode } from "react";
+
+export default function AdminRoute({ need, children }: { need: string; children: ReactNode }) {
+  const { perms } = useAuth();
+  const has = (p: string) => perms.includes("admin:all") || perms.includes(p);
+  if (!has("admin:panel") || !has(need)) {
+    return <Navigate to="/home" replace />;
+  }
+  return <>{children}</>;
+}
+

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,11 +2,11 @@
 import { Layout, Menu, Badge } from "antd";
 import type { MenuProps } from "antd";
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
-import { DollarOutlined, FlagOutlined, HomeOutlined, PlusOutlined, RetweetOutlined, SendOutlined, TeamOutlined, ToolOutlined, UsergroupAddOutlined } from "@ant-design/icons";
+import { DollarOutlined, FlagOutlined, HomeOutlined, PlusOutlined, RetweetOutlined, SendOutlined, TeamOutlined, ToolOutlined } from "@ant-design/icons";
 import { useEffect, useMemo, useState } from "react";
 import { useReportNewCount } from "../hooks/useReportNewCount";
 import type { ItemType } from "antd/es/menu/interface";
-import { FlagIcon } from "lucide-react";
+import { useAuth } from "../context/AuthContext";
 
 const { Sider, Content } = Layout;
 type GroupItem = Required<MenuProps>["items"][number];
@@ -17,6 +17,8 @@ const Sidebar = () => {
 
   // ✅ นับเคสใหม่ทุก 8s (หรือปรับตามต้องการ)
   const reportCount = useReportNewCount(8000);
+  const { perms } = useAuth();
+  const has = (p: string) => perms.includes("admin:all") || perms.includes(p);
 
   const rootSubmenuKeys = useMemo(() => ["/information", "/category", "/Admin"], []);
   const selectedKey = location.pathname;
@@ -46,27 +48,27 @@ const Sidebar = () => {
   );
 
   const items: ItemType[] = [
-    { key: "/home", label: "หน้าแรก", icon: <HomeOutlined/> },
+    { key: "/home", label: "หน้าแรก", icon: <HomeOutlined /> },
     { key: "/request", label: "รีเควสเกม", icon: <SendOutlined /> },
     { key: "/category/Community", label: "ชุมชน", icon: <TeamOutlined /> },
-    { key: "/category/Payment", label: "การชำระเงิน", icon: <DollarOutlined /> }, 
-    { key: "/workshop", label: "Workshop", icon: <ToolOutlined /> },  
-    { key: "/refund", label: "การคืนเงินผู้ใช้", icon: <RetweetOutlined/> },
+    { key: "/category/Payment", label: "การชำระเงิน", icon: <DollarOutlined /> },
+    { key: "/workshop", label: "Workshop", icon: <ToolOutlined /> },
+    { key: "/refund", label: "การคืนเงินผู้ใช้", icon: <RetweetOutlined /> },
     { key: "/report", label: "รายงานปัญหา", icon: <FlagOutlined /> },
-    {
-      key: "/Admin",
-      label: "Admin",
-      children: [
-        { key: "/information/Add", label: "เพิ่มเกม", icon: <PlusOutlined /> },
-        { key: "/requestinfo", label: "ข้อมูลรีเควส", icon: <PlusOutlined /> },
-        { key: "/promotion", label: "Promotion", icon: <PlusOutlined />  },
-        { key: "/Admin/Page", label: adminPageLabel, icon: <PlusOutlined />,},
-        { key: "/Admin/PaymentReviewPage",label: "PaymentReview", icon: <PlusOutlined />,},
-        { key: "/Admin/RolePage", label: "Role", icon: <PlusOutlined /> },
-        
-      ],
-    },
   ];
+
+  if (has("admin:panel")) {
+    const children: ItemType[] = [];
+    if (has("admin:game")) children.push({ key: "/information/Add", label: "เพิ่มเกม", icon: <PlusOutlined /> });
+    if (has("admin:request")) children.push({ key: "/requestinfo", label: "ข้อมูลรีเควส", icon: <PlusOutlined /> });
+    if (has("admin:promotion")) children.push({ key: "/promotion", label: "Promotion", icon: <PlusOutlined /> });
+    if (has("admin:page")) children.push({ key: "/Admin/Page", label: adminPageLabel, icon: <PlusOutlined /> });
+    if (has("admin:paymentreview")) children.push({ key: "/Admin/PaymentReviewPage", label: "PaymentReview", icon: <PlusOutlined /> });
+    if (has("admin:role")) children.push({ key: "/Admin/RolePage", label: "Role", icon: <PlusOutlined /> });
+    if (children.length > 0) {
+      items.push({ key: "/Admin", label: "Admin", children });
+    }
+  }
 
   return (
     <Layout style={{ minHeight: "100vh" }}>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,20 +1,26 @@
-import { createContext, useState, useContext } from 'react';
+import { createContext, useState, useContext, useEffect } from 'react';
 import type { ReactNode } from 'react';
 
 interface AuthContextType {
   id: number | null;
   token: string | null;
   username: string | null;
+  roles: string[];
+  perms: string[];
   login: (id:number, token: string, username: string) => void;
   logout: () => void;
+  refreshPerms: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType>({
   id: null,
   token: null,
   username: null,
-  login: () => {},
+  roles: [],
+  perms: [],
+  login: async () => {},
   logout: () => {},
+  refreshPerms: async () => {},
 });
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
@@ -24,6 +30,30 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const s = localStorage.getItem("userid");
     return s ? Number(s) : null;
   });
+  const [roles, setRoles] = useState<string[]>([]);
+  const [perms, setPerms] = useState<string[]>([]);
+
+  const refreshPerms = async (t?: string) => {
+    const tok = t ?? token;
+    if (!tok) {
+      setRoles([]);
+      setPerms([]);
+      return;
+    }
+    try {
+      const res = await fetch("/me/permissions", {
+        headers: { Authorization: `Bearer ${tok}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setRoles(data.roles || []);
+        setPerms(data.perms || []);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
+
   const login = (newId: number, newToken: string, name: string) => {
     setId(newId);
     setToken(newToken);
@@ -31,19 +61,41 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     localStorage.setItem('token', newToken);
     localStorage.setItem('username', name);
     localStorage.setItem('userid', String(newId));
+    refreshPerms(newToken);
   };
 
   const logout = () => {
     setId(null);
     setToken(null);
     setUsername(null);
+    setRoles([]);
+    setPerms([]);
     localStorage.removeItem('token');
     localStorage.removeItem('username');
     localStorage.removeItem('userid');
   };
 
+  useEffect(() => {
+    refreshPerms();
+  }, [token]);
+
+  // intercept fetch 403 to refresh permissions
+  useEffect(() => {
+    const orig = window.fetch;
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const res = await orig(input, init);
+      if (res.status === 403) {
+        refreshPerms();
+      }
+      return res;
+    };
+    return () => {
+      window.fetch = orig;
+    };
+  }, [token]);
+
   return (
-    <AuthContext.Provider value={{ id, token, username, login, logout }}>
+    <AuthContext.Provider value={{ id, token, username, roles, perms, login, logout, refreshPerms }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/routes/text.tsx
+++ b/frontend/src/routes/text.tsx
@@ -2,6 +2,7 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
 
 import Sidebar from "../components/Sidebar";
+import AdminRoute from "../components/AdminRoute";
 
 // pages
 import Home from "../pages/Home";
@@ -59,12 +60,12 @@ const router = createBrowserRouter([
       { path: "report/success", element: <ReportSuccessPage /> },
 
       // === กลุ่ม information
-      { path: "information/Add", element: <Add /> },
+      { path: "information/Add", element: <AdminRoute need="admin:game"><Add /></AdminRoute> },
       { path: "information/Edit", element: <Edit /> },
 
       // === request
       { path: "request", element: <Request /> },
-      { path: "requestinfo", element: <Requestinfo /> },
+      { path: "requestinfo", element: <AdminRoute need="admin:request"><Requestinfo /></AdminRoute> },
 
       // === category (ใช้ path แบบ relative)
       {
@@ -85,11 +86,11 @@ const router = createBrowserRouter([
        { path: "game/:id", element: <GameDetail /> },
 
       // === promotion
-      { path: "promotion", element: <PromotionManager /> },
-      { path: "promotion/:id", element: <PromotionDetail /> },
+      { path: "promotion", element: <AdminRoute need="admin:promotion"><PromotionManager /></AdminRoute> },
+      { path: "promotion/:id", element: <AdminRoute need="admin:promotion"><PromotionDetail /></AdminRoute> },
       // === roles
-      { path: "roles", element: <RoleManagement /> },
-      { path: "roles/:id", element: <RoleEdit /> },
+      { path: "roles", element: <AdminRoute need="admin:role"><RoleManagement /></AdminRoute> },
+      { path: "roles/:id", element: <AdminRoute need="admin:role"><RoleEdit /></AdminRoute> },
 
       // === refund
       { path: "refund", element: <RefundPage /> },
@@ -108,20 +109,22 @@ const router = createBrowserRouter([
       {
         path: "Admin/Page",
         element: (
-          <AdminPage
-            refunds={refunds}
-            setRefunds={() => { }}
-            addNotification={addNotification}
-            addRefundUpdate={addRefundUpdate}
-          />
+          <AdminRoute need="admin:page">
+            <AdminPage
+              refunds={refunds}
+              setRefunds={() => { }}
+              addNotification={addNotification}
+              addRefundUpdate={addRefundUpdate}
+            />
+          </AdminRoute>
         ),
       },
-      { path: "Admin/PaymentReviewPage", element: <AdminPaymentReviewPage /> },
+      { path: "Admin/PaymentReviewPage", element: <AdminRoute need="admin:paymentreview"><AdminPaymentReviewPage /></AdminRoute> },
 
-      { path: "Admin/RolePage", element: <RoleManagement /> },
+      { path: "Admin/RolePage", element: <AdminRoute need="admin:role"><RoleManagement /></AdminRoute> },
 
       // ✅ เพิ่มเส้นทางหน้ารายการที่แก้ไขแล้ว (ตรงกับปุ่ม navigate("/Admin/Resolved"))
-      { path: "Admin/Resolved", element: <ResolvedReportsPage /> },
+      { path: "Admin/Resolved", element: <AdminRoute need="admin:page"><ResolvedReportsPage /></AdminRoute> },
 
       // === ✅ สถานะคำสั่งซื้อ (เส้นทางที่ต้องการ)
       { path: "orders-status", element: <OrdersStatusPage /> },


### PR DESCRIPTION
## Summary
- seed only admin:* permissions and grant admin:all/admin:panel to admin role
- add middleware for checking admin permissions and expose /me/permissions
- gate admin APIs and frontend routes/menus based on new permissions

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c57f25ba0c832aa9b56638af8820a1