### PR TITLE
Cleanup permissions seed and align admin role

### DIFF
--- a/backend/configs/db.go
+++ b/backend/configs/db.go
@@ -275,9 +275,19 @@ func seedPermissionsAndGrantAdmin(adminID uint) {
 	// สำรองข้อมูลเดิมของ permissions (ทำครั้งแรกเท่านั้น)
 	db.Exec("CREATE TABLE IF NOT EXISTS permissions_backup AS SELECT * FROM permissions")
 
-	// ลบรายการที่ไม่ใช่ admin:* ทั้งหมด
-	if err := db.Exec("DELETE FROM permissions WHERE key NOT LIKE ?", "admin:%").Error; err != nil {
+	// ลบรายการที่ไม่ใช่ admin:* หรือ key ว่าง/NULL ทั้งหมด
+	if err := db.Exec(
+		"DELETE FROM permissions WHERE key IS NULL OR key = '' OR key NOT LIKE ?",
+		"admin:%",
+	).Error; err != nil {
 		log.Println("cleanup permissions error:", err)
+	}
+
+	// ลบ role_permissions ที่ชี้ไปยัง permission ที่ถูกลบแล้ว
+	if err := db.Exec(
+		"DELETE FROM role_permissions WHERE permission_id NOT IN (SELECT id FROM permissions)",
+	).Error; err != nil {
+		log.Println("cleanup role_permissions error:", err)
 	}
 
 	// รายการสิทธิ์ใหม่เฉพาะฝั่ง Admin


### PR DESCRIPTION
## Summary
- remove stale permissions with blank keys and purge orphaned role permissions
- ensure admin role is granted admin:all and admin:panel

## Testing
- `go test ./...`
- `curl -s -H 'X-User-ID: 1' http://localhost:8088/me/permissions`


------
https://chatgpt.com/codex/tasks/task_e_68c5f9e6afb8832aa8b5599ee02b7e5e